### PR TITLE
Fixed npm start errors

### DIFF
--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -15,11 +15,6 @@ export default {
   },
 
   plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        warnings: false
-      }
-    }),
     new webpack.BannerPlugin(
       'require("source-map-support").install();',
       { raw: true, entryOnly: false }
@@ -36,6 +31,10 @@ export default {
   node: {
     __dirname: false,
     __filename: false
+  },
+
+  resolve: {
+    packageAlias: 'main'
   },
 
   externals: [

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -7,7 +7,7 @@ const config = {
 
   devtool: 'source-map',
 
-  entry: './app/index',
+  entry: ['babel-polyfill', './app/index'],
 
   output: {
     ...baseConfig.output,


### PR DESCRIPTION
-Removed Uglifying of NodeJS code because it currently is incompatible with ESHarmony
-Point Node NPM packages entry points to 'main' (webpack does 'browser' by default). Pointing packages to 'browser' caused the code to break because of Reference Errors (window is not defined)
-Added 'babel-polyfill' to renderer webpack entry points