### PR TITLE
Set TreeNode children to null if no children

### DIFF
--- a/app/components/Inspector/Source.js
+++ b/app/components/Inspector/Source.js
@@ -35,6 +35,7 @@ export default class Source extends Component {
     // Recursives through the source and renders a TreeNode for an element
     let recursive = (elemObj) => {
       if (!elemObj) return null;
+      if (elemObj.children.length === 0) return null;
 
       return elemObj.children.map((el) => {
         return <TreeNode title={this.getFormattedTag(el)} key={el.path}>


### PR DESCRIPTION
If an empty array is passed into a treenode it still shows the expander arrow. Instead of passing an empty array it passes null.