### PR TITLE
use shell-env to ensure we get env vars when running the app (fix #45)

### DIFF
--- a/app/main/main.development.js
+++ b/app/main/main.development.js
@@ -2,6 +2,7 @@ import { app, BrowserWindow, Menu } from 'electron';
 import { initializeIpc } from './appium';
 import menuTemplates from './menus';
 import path from 'path';
+import shellEnv from 'shell-env';
 
 let menu;
 let template;
@@ -13,6 +14,13 @@ const indexPath = path.resolve(__dirname, isDev ? '..' : 'app');
 
 if (isDev) {
   require('electron-debug')(); // eslint-disable-line global-require
+}
+
+if (!isDev) {
+  // if we're running from the app package, we won't have access to env vars
+  // normally loaded in a shell, so work around with the shell-env module
+  const decoratedEnv = shellEnv.sync();
+  process.env = {...process.env, ...decoratedEnv};
 }
 
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-router-redux": "4.x",
     "redux": "3.x",
     "redux-thunk": "2.x",
+    "shell-env": "^0.3.0",
     "source-map-support": "0.x",
     "teen_process": "1.x",
     "temp": "0.x",

--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -18,12 +18,7 @@ export default {
     new webpack.BannerPlugin(
       'require("source-map-support").install();',
       { raw: true, entryOnly: false }
-    ),
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production')
-      }
-    })
+    )
   ],
 
   target: 'electron-main',


### PR DESCRIPTION
check it out @dpgraham 