### PR TITLE
Add logging to autoUpdater and fixed functionality

### DIFF
--- a/app/main/auto-updater.js
+++ b/app/main/auto-updater.js
@@ -1,8 +1,14 @@
 import { autoUpdater } from 'electron-updater';
+import log from 'electron-log';
 import { ipcMain, BrowserWindow, Menu } from 'electron';
 import path from 'path';
 import _ from 'lodash';
 const isDev = process.env.NODE_ENV === 'development';
+
+// Logs data to 
+autoUpdater.logger = log;
+autoUpdater.logger.transports.file.level = 'info';
+log.info('Auto updater starting');
 
 // Mock auto updater. Used to aid development because testing using actual releases is super tedious.
 if (process.env.NODE_ENV === 'development') {
@@ -44,6 +50,7 @@ class AutoUpdaterController {
   }
 
   handleUpdateAvailable (updateInfo) {
+    log.info('Found update', updateInfo);
     // If window not open, open it to notify user
     this.openUpdaterWindow(this.mainWindow);
     this.forceFocus();
@@ -54,18 +61,21 @@ class AutoUpdaterController {
   }
 
   handleUpdateNotAvailable () {
+    log.info('No update available');
     this.setState({
       hasNoUpdateAvailable: true,
     });
   }
 
   handleCheckingForUpdate () {
+    log.info('Looking for updates');
     this.setState({
       checkingForUpdate: true,
     });
   }
 
   handleDownloadProgress (downloadProgress) {
+    log.info('Downloading...', downloadProgress);
     this.updaterWin.setSize(500, 100);
     this.setState({
       downloadProgress
@@ -73,6 +83,7 @@ class AutoUpdaterController {
   }
 
   handleUpdateDownloaded (updateInfo) {
+    log.info('Download complete', updateInfo);
     // Focus on window when the download is done to get the user's attention
     this.forceFocus();
     this.setState({
@@ -82,6 +93,7 @@ class AutoUpdaterController {
   }
 
   handleError (error) {
+    log.info('Updater error occurred', error);
     this.updaterWin.setSize(500, 125);
     this.setState({
       error,
@@ -95,6 +107,7 @@ class AutoUpdaterController {
   }
 
   checkForUpdates () {
+    log.info('Checking for updates');
     this.setState({
       isCheckingForUpdates: true,
     });

--- a/app/main/auto-updater.js
+++ b/app/main/auto-updater.js
@@ -40,13 +40,23 @@ class AutoUpdaterController {
 
     ipcMain.on('update-state-request', (e) => e.sender.send('update-state-change', this.state));
     ipcMain.on('update-check-for-updates', autoUpdater.checkForUpdates || _.noop);
-    ipcMain.on('update-download', autoUpdater.downloadUpdate || _.noop);
+    ipcMain.on('update-download', this.downloadUpdate.bind(this));
     ipcMain.on('update-quit-and-install', autoUpdater.quitAndInstall || _.noop);
 
   }
 
   setMainWindow (mainWindow) {
     this.mainWindow = mainWindow;
+  }
+
+  downloadUpdate () {
+    this.updaterWin.setSize(500, 100);
+    this.setState({
+      downloadProgress: {
+        percent: 0,
+      },
+    });
+    autoUpdater.downloadUpdate && autoUpdater.downloadUpdate();
   }
 
   handleUpdateAvailable (updateInfo) {
@@ -76,7 +86,6 @@ class AutoUpdaterController {
 
   handleDownloadProgress (downloadProgress) {
     log.info('Downloading...', downloadProgress);
-    this.updaterWin.setSize(500, 100);
     this.setState({
       downloadProgress
     });

--- a/app/main/mock-updater.js
+++ b/app/main/mock-updater.js
@@ -35,11 +35,11 @@ autoUpdater.downloadUpdate = async () => {
   };
 
   while (progress.percent <= 100) {
+    await B.delay(2000);
     autoUpdater.emit('download-progress', progress);
     if (fail && progress.percent > 50) {
       return autoUpdater.emit('error', new Error('An error occurred'));
     }
-    await B.delay(1000);
     progress.bytesPerSecond += (Math.random() * 50) - 25;
     progress.percent += 20;
     progress.total = 500;

--- a/app/renderer/components/Updater/DownloadUpdate.js
+++ b/app/renderer/components/Updater/DownloadUpdate.js
@@ -15,8 +15,8 @@ export default class DownloadUpdate extends Component {
 
     return <div className={UpdaterStyles['download-updates-container']}>
       <p>
-        {!updateDownloaded && <span>Downloading: {Math.round(bytesPerSecond * 100) / 100} bps</span>}
-        {!updateDownloaded && <span>&nbsp;(transferred: {transferred} / {total} bytes)</span>}
+        {!updateDownloaded && <span>Downloading: {bytesPerSecond ? Math.round(bytesPerSecond * 100) / 100 : '-'} bps</span>}
+        {!updateDownloaded && <span>&nbsp;(transferred: {transferred || 0} / {total || '-'} bytes)</span>}
         {updateDownloaded && <p>Download Complete</p>}
       </p>
       <Progress percent={!updateDownloaded ? percent : 100}></Progress>


### PR DESCRIPTION
* The autoUpdater has a `download-progress`. Previously we were waiting for that event to be emitted before we show the download indicator, but it turns out that in practice the download starts before the first `download-progress` event is ever emitted, so this fix shows the indicator right away