### PR TITLE
Use flex to align items in FoundUpdate component

### DIFF
--- a/app/main/mock-updater.js
+++ b/app/main/mock-updater.js
@@ -9,7 +9,7 @@ autoUpdater.checkForUpdates = async () => {
     await B.delay(Math.random() * 10000);
     autoUpdater.emit('update-available', {
       version: 'v0.0.0',
-      releaseDate: 'July 24th, 1985',
+      releaseDate: 'July 24th, 1985 asdfasdf asdfafds asdf  asdf  asfd asadfasd as dff',
       releaseNotes: `
           1. Feature 1
           2. Feature 2

--- a/app/renderer/components/Updater/FoundUpdate.js
+++ b/app/renderer/components/Updater/FoundUpdate.js
@@ -15,8 +15,8 @@ export default class FoundUpdate extends Component {
     const {releaseDate, releaseNotes, version} = updateInfo;
 
     return <div className={UpdaterStyles['found-updates-container']}>
+      <h3>A new version of Appium Desktop is available: <span className={UpdaterStyles['release-info']}><span>{version}</span> released <span>{releaseDate}</span></span></h3>
       <div>
-        <h3>A new version of Appium Desktop is available: <span className={UpdaterStyles['release-info']}><span>{version}</span> released <span>{releaseDate}</span></span></h3>
         <textarea value={releaseNotes}></textarea>
       </div>
       <footer>

--- a/app/renderer/components/Updater/Updater.css
+++ b/app/renderer/components/Updater/Updater.css
@@ -19,29 +19,34 @@
   margin: 20vh 0 5vh 0;
 }
 
-.found-updates-container > div {
-  height: 80vh;
-  padding: 1em;
+.found-updates-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
-.found-updates-container > div h3 {
+.found-updates-container > h3 {
   font-size: 12px;
-  height: 10vh;
+  padding: 1em;
 }
 
 .found-updates-container > div h3 .release-info {
   font-style: italic;
 }
 
+.found-updates-container > div {
+  padding: 0 1em 1em 1em;
+  flex-grow: 1;
+  display: flex;
+}
+
 .found-updates-container > div textarea {
   width: 100%;
-  height: 60vh;
 }
 
 .found-updates-container footer {
   border-top: 1px solid #d9d9d9;
-  height: 20vh;
-  text-align: right;
+  text-align: right;  
 }
 
 .found-updates-container footer button {


### PR DESCRIPTION
* Was using percentage previously and header was getting clipped
* Now it sets the container to column flex with  height 100% of viewport
* The header and footer don't have flex-grow set
* The body (which contains the 'release notes' textarea) has flex-grow=1 which causes it to take up all the remaining space
* The body is also given a 'flex' display type which causes it's children to take up all the space (height 100% on textarea doesn't work)