### PR TITLE
Get release notes from GitHub API

### DIFF
--- a/app/main/auto-updater.js
+++ b/app/main/auto-updater.js
@@ -3,6 +3,8 @@ import log from 'electron-log';
 import { ipcMain, BrowserWindow, Menu } from 'electron';
 import path from 'path';
 import _ from 'lodash';
+import request from 'request-promise';
+import { version } from '../../package.json';
 const isDev = process.env.NODE_ENV === 'development';
 
 // Logs data to 
@@ -59,14 +61,21 @@ class AutoUpdaterController {
     autoUpdater.downloadUpdate && autoUpdater.downloadUpdate();
   }
 
-  handleUpdateAvailable (updateInfo) {
+  async handleUpdateAvailable (updateInfo) {
     log.info('Found update', updateInfo);
+    let releaseNotes;
+    try {
+      let url = `https://api.github.com/repos/appium/appium-desktop/releases/tags/v${version}`;
+      let userAgent = 'appium-desktop';
+      releaseNotes = JSON.parse(await request({url, headers: {'User-Agent': userAgent}})).body;
+    } catch (ign) { }
     // If window not open, open it to notify user
     this.openUpdaterWindow(this.mainWindow);
     this.forceFocus();
     this.setState({
       hasUpdateAvailable: true,
       updateInfo,
+      releaseNotes,
     });
   }
 

--- a/app/renderer/components/Updater/FoundUpdate.js
+++ b/app/renderer/components/Updater/FoundUpdate.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Button } from 'antd';
-import { ipcRenderer, remote } from 'electron';
+import { ipcRenderer, remote, shell } from 'electron';
 import UpdaterStyles from './Updater.css';
 
 export default class FoundUpdate extends Component {
@@ -18,6 +18,7 @@ export default class FoundUpdate extends Component {
       <h3>A new version of Appium Desktop is available: <span className={UpdaterStyles['release-info']}><span>{version}</span> released <span>{releaseDate}</span></span></h3>
       <div>
         {releaseNotes && <textarea defaultValue={releaseNotes}></textarea>}
+        {!releaseNotes && <span>Release notes could not be found. To view changes since the last version, visit <a href='#' onClick={() => shell.openExternal('https://github.com/appium/appium-desktop/releases')}>https://github.com/appium/appium-desktop/releases</a>.</span> }
       </div>
       <footer>
         <Button type='primary' onClick={() => ipcRenderer.send('update-download')}>Download Update Now</Button>

--- a/app/renderer/components/Updater/FoundUpdate.js
+++ b/app/renderer/components/Updater/FoundUpdate.js
@@ -6,18 +6,18 @@ import UpdaterStyles from './Updater.css';
 export default class FoundUpdate extends Component {
 
   render () {
-    const {hasUpdateAvailable, updateInfo} = this.props;
+    const {hasUpdateAvailable, updateInfo, releaseNotes} = this.props;
 
     if (!hasUpdateAvailable) {
       return null;
     }
 
-    const {releaseDate, releaseNotes, version} = updateInfo;
+    const {releaseDate, version} = updateInfo;
 
     return <div className={UpdaterStyles['found-updates-container']}>
       <h3>A new version of Appium Desktop is available: <span className={UpdaterStyles['release-info']}><span>{version}</span> released <span>{releaseDate}</span></span></h3>
       <div>
-        <textarea defaultValue={releaseNotes}></textarea>
+        {releaseNotes && <textarea defaultValue={releaseNotes}></textarea>}
       </div>
       <footer>
         <Button type='primary' onClick={() => ipcRenderer.send('update-download')}>Download Update Now</Button>

--- a/app/renderer/components/Updater/Updater.css
+++ b/app/renderer/components/Updater/Updater.css
@@ -42,6 +42,7 @@
 
 .found-updates-container > div textarea {
   width: 100%;
+  padding: 1em;
 }
 
 .found-updates-container footer {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "react-router-redux": "4.x",
     "redux": "3.x",
     "redux-thunk": "2.x",
+    "request-promise": "^4.1.1",
     "shell-env": "^0.3.0",
     "source-map-support": "0.x",
     "teen_process": "1.x",


### PR DESCRIPTION
* Get version from package.json
* Call endpoint to get release notes for that version (https://api.github.com/repos/appium/appium-desktop/releases/tags/v${version}) from auto-updater.js
* Also added padding to textarea (it looked weird with no padding)