### PR TITLE
Do not quit attached session when closing the inspector

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -151,7 +151,9 @@ export function createNewSessionWindow (win) {
   sessionWin.on('closed', async () => {
     const driver = sessionDrivers[sessionID];
     if (driver) {
-      if (!driver._isAttachedSession) await driver.quit();
+      if (!driver._isAttachedSession) {
+        await driver.quit();
+      }
       delete sessionDrivers[sessionID];
     }
     sessionWin = null;

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -149,8 +149,9 @@ export function createNewSessionWindow (win) {
   // When you close the session window, kill its associated Appium session (if there is one)
   let sessionID = sessionWin.webContents.id;
   sessionWin.on('closed', async () => {
-    if (sessionDrivers[sessionID]) {
-      await sessionDrivers[sessionID].quit();
+    const driver = sessionDrivers[sessionID];
+    if (driver) {
+      if (!driver._isAttachedSession) await driver.quit();
       delete sessionDrivers[sessionID];
     }
     sessionWin = null;


### PR DESCRIPTION
Attached sessions get terminated when closing the inspector, which is quite annoying in my opinion. The initiator of the session should be responsible for deleting it.