### PR TITLE
Remove max-height on .ant-spin

### DIFF
--- a/app/renderer/app.global.css
+++ b/app/renderer/app.global.css
@@ -8,6 +8,10 @@ body {
   background: linear-gradient(180deg, #f9f9f9, #f2f2f2, 5%, #f2f2f2, 95%, #d9d9d9);
 }
 
+#root .ant-spin-nested-loading > div > .ant-spin {
+  max-height: initial;
+}
+
 .window {
   background-color: #cde4f5 !important;
   width: 100%;


### PR DESCRIPTION
For some reason antd has a max height on the ant-spin of 320 px which was causing the spinner to not be centered