### PR TITLE
Fix for xpath parse exception

### DIFF
--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -85,7 +85,7 @@ export default class SelectedElement extends Component {
       }
     }
 
-    if (!findDataSource.length) {
+    if (!findDataSource.length && xpath) {
       findDataSource.push({
         key: 'xpath',
         find: 'xpath',
@@ -99,7 +99,7 @@ export default class SelectedElement extends Component {
         <Col><Button onClick={() => applyClientMethod({methodName: 'click', xpath})}>Tap</Button></Col>
         <Col><Button onClick={() => showSendKeysModal()}>Send Keys</Button></Col>
       </Row>
-      <Table columns={findColumns} dataSource={findDataSource} size="small" pagination={false} />
+      {findDataSource.length > 0 && <Table columns={findColumns} dataSource={findDataSource} size="small" pagination={false} />}
       <br />
       {showXpathWarning &&
         <div>

--- a/app/renderer/util.js
+++ b/app/renderer/util.js
@@ -6,45 +6,57 @@ import XPath from 'xpath';
  * @param {*} uniqueAttributes {array[string]} Attributes we know are unique (defaults to just 'id')
  */
 export function getOptimalXPath (doc, domNode, uniqueAttributes = ['id']) {
-  // BASE CASE #1: If this isn't an element, we're above the root, return empty string
-  if (!domNode.tagName) {
-    return '';
-  }
+  try {
+    // BASE CASE #1: If this isn't an element, we're above the root, return empty string
+    if (!domNode.tagName || domNode.nodeType !== 1) {
+      return '';
+    }
 
-  // BASE CASE #2: If this node has a unique attribute, return an absolute XPath with that attribute
-  for (let attrName of uniqueAttributes) {
-    const attrValue = domNode.getAttribute(attrName);
-    if (attrValue) {
-      let xpath = `//${domNode.tagName}[@${attrName}="${attrValue}"]`;
-      const othersWithAttr = XPath.select(xpath, doc);
+    // BASE CASE #2: If this node has a unique attribute, return an absolute XPath with that attribute
+    for (let attrName of uniqueAttributes) {
+      const attrValue = domNode.getAttribute(attrName);
+      if (attrValue) {
+        let xpath = `//${domNode.tagName || '*'}[@${attrName}="${attrValue}"]`;
+        let othersWithAttr;
 
-      // If the attribute isn't actually unique, get it's index too
-      if (othersWithAttr.length > 1) {
-        let index = othersWithAttr.indexOf(domNode);
-        xpath = `(${xpath})[${index + 1}]`;
+        // If the XPath does not parse, move to the next unique attribute
+        try {
+          othersWithAttr = XPath.select(xpath, doc);
+        } catch (ign) {
+          continue;
+        }
+
+        // If the attribute isn't actually unique, get it's index too
+        if (othersWithAttr.length > 1) {
+          let index = othersWithAttr.indexOf(domNode);
+          xpath = `(${xpath})[${index + 1}]`;
+        }
+        return xpath;
       }
-      return xpath;
     }
-  }
 
 
-  // Get the relative xpath of this node using tagName
-  let xpath = `/${domNode.tagName}`;
+    // Get the relative xpath of this node using tagName
+    let xpath = `/${domNode.tagName}`;
 
-  // If this node has siblings of the same tagName, get the index of this node
-  if (domNode.parentNode) {
-    // Get the siblings
-    const childNodes = [...domNode.parentNode.childNodes].filter((childNode) => (
-      childNode.nodeType === 1 && childNode.tagName === domNode.tagName
-    )); 
-    
-    // If there's more than one sibling, append the index
-    if (childNodes.length > 1) {
-      let index = childNodes.indexOf(domNode);
-      xpath +=  `[${index + 1}]`;
+    // If this node has siblings of the same tagName, get the index of this node
+    if (domNode.parentNode) {
+      // Get the siblings
+      const childNodes = [...domNode.parentNode.childNodes].filter((childNode) => (
+        childNode.nodeType === 1 && childNode.tagName === domNode.tagName
+      )); 
+      
+      // If there's more than one sibling, append the index
+      if (childNodes.length > 1) {
+        let index = childNodes.indexOf(domNode);
+        xpath +=  `[${index + 1}]`;
+      }
     }
-  }
 
-  // Make a recursive call to this nodes parents and prepend it to this xpath
-  return getOptimalXPath(doc, domNode.parentNode, uniqueAttributes) + xpath;
+    // Make a recursive call to this nodes parents and prepend it to this xpath
+    return getOptimalXPath(doc, domNode.parentNode, uniqueAttributes) + xpath;
+  } catch (ign) {
+    // If there's an unexpected exception, abort and don't get an XPath
+    return null;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "react-addons-test-utils": "15.x",
     "redux-logger": "2.x",
     "request": "^2.79.0",
+    "sinon": "^2.2.0",
     "spectron": "^3.6.0",
     "style-loader": "0.x",
     "webpack": "1.x",


### PR DESCRIPTION
* Added try-catch so that if XPath.select throws an exception within the for loop, it just continues the loop and skips past the attribute that it's testing
* Added another try-catch within the entire method so that if there is some other unexpeccted exception, it returns null and we don't show xpath on the selected elements pane (this case is unlikely given that XPath.select is the only method that we would expect to throw an exception)
* Added regression tests that reproduce the above exceptions and confirmed the fix

(reviewer @jlipps)