### PR TITLE
Increase e2e test timeout on AppVeyor

### DIFF
--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -5,7 +5,7 @@ var platform = os.platform();
 var path = require('path');
 
 describe('application launch', function () {
-  this.timeout(process.env.TRAVIS ? 10 * 60 * 1000 : 30 * 1000);
+  this.timeout(process.env.TRAVIS || process.env.APPVEYOR ? 10 * 60 * 1000 : 30 * 1000);
 
   var appPath;
   if (platform === 'linux') {


### PR DESCRIPTION
* Travis already has the e2e timeout set to 10 minutes
* Increase AppVeyor to 10 minutes too (AppVeyor was sometimes timing out and this was breaking build)

(reviewer @jlipps)