### PR TITLE
Gets list of running sessions from Appium

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,14 @@ the Appium Desktop Inspector.
 
 #### Attach to an Existing Session
 
-If you click on the "Attach to Session..." tab, you'll be able to enter
-a session ID of a currently-running session. That session should be running on
-the server details you specified in the server type section above. Attaching to
-an existing session is possible because the Inspector is just an Appium client.
-This could be useful if you want to debug the middle of a running test. When
-you quit the Inspector window of an existing session, Appium Desktop will not
-quit the session as it does normally.
+If you click on the "Attach to Session..." tab, you can select an existing 
+session from a list of currently running sessions on your selected server, or you 
+can input a session ID of a currently-running session.  That session should be 
+running on the server details you specified in the server type section above. 
+Attaching to an existing session is possible because the Inspector is just an 
+Appium client. This could be useful if you want to debug the middle of a running 
+test. When you quit the Inspector window of an existing session, Appium Desktop 
+will not quit the session as it does normally.
 
 ### The Inspector
 

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -35,6 +35,9 @@ export const SERVER_ARGS = 'SERVER_ARGS';
 
 export const SET_ATTACH_SESS_ID = 'SET_ATTACH_SESS_ID';
 
+export const GET_SESSIONS_REQUESTED = 'GET_SESSIONS_REQUESTED';
+export const GET_SESSIONS_DONE = 'GET_SESSIONS_DONE';
+
 export const ServerTypes = {
   local: 'local',
   remote: 'remote',
@@ -374,5 +377,19 @@ export function setSavedServerParams () {
     if (server) {
       dispatch({type: SET_SERVER, server, serverType});
     }
+  };
+}
+
+export function getRunningSessions (host, port, ssl) {
+  return (dispatch) => {
+    dispatch({type: GET_SESSIONS_REQUESTED});
+    ipcRenderer.send('appium-client-get-sessions', {host, port, ssl});
+    ipcRenderer.once('appium-client-get-sessions-response', (evt, e) => {
+      const res = JSON.parse(e.res);
+      dispatch({type: GET_SESSIONS_DONE, sessions: res.value});
+    });
+    ipcRenderer.once('appium-client-get-sessions-fail', () => {
+      dispatch({type: GET_SESSIONS_DONE});
+    });
   };
 }

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -3,6 +3,7 @@ import settings from '../../settings';
 import { v4 as UUID } from 'uuid';
 import { push } from 'react-router-redux';
 import { notification } from 'antd';
+import { debounce } from 'lodash';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';
 export const NEW_SESSION_BEGAN = 'NEW_SESSION_BEGAN';
@@ -340,9 +341,10 @@ export function changeServerType (serverType) {
  * Set a server parameter (host, port, etc...)
  */
 export function setServerParam (name, value) {
+  const debounceGetRunningSessions = debounce(getRunningSessions(), 500);
   return (dispatch, getState) => {
     dispatch({type: SET_SERVER_PARAM, serverType: getState().session.serverType, name, value});
-    getRunningSessions()(dispatch, getState);
+    debounceGetRunningSessions(dispatch, getState);
   };
 }
 

--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -26,6 +26,7 @@ export default class AttachToSession extends Component {
         <Row>
           <Col span={23}>
             <Select showSearch 
+              mode='combobox'
               notFoundContent='None found'
               value={attachSessId}
               onChange={(value) => setAttachSessId(value)}>

--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -1,21 +1,43 @@
 import React, { Component } from 'react';
-import { Form, Input, Card } from 'antd';
+import { Form, Card, Select, Button, Row, Col } from 'antd';
 import SessionCSS from './Session.css';
 
 const FormItem = Form.Item;
 
+function formatCaps (caps) {
+  let importantCaps = [caps.app, caps.platformName, caps.deviceName];
+  if (caps.automationName) {
+    importantCaps.push(caps.automationName);
+  }
+  return importantCaps.join(', ').trim();
+}
+
 export default class AttachToSession extends Component {
 
   render () {
-    let {attachSessId, setAttachSessId} = this.props;
+    let {attachSessId, setAttachSessId, runningAppiumSessions, getRunningSessions} = this.props;
     return (<Form>
       <FormItem>
         <Card>
-          <p className={SessionCSS.localDesc}>If you have an already-running session of the above server type, you can attach an inspector to it directly.<br/>Simply enter the session ID in the box below.</p>
+          <p className={SessionCSS.localDesc}>If you have an already-running session of the above server type, you can attach an inspector to it directly.<br/>Select the Session ID in the dropdown below.</p>
         </Card>
       </FormItem>
       <FormItem>
-        <Input placeholder='1234-5789-1234-57890' addonBefore="Session ID" value={attachSessId} onChange={(e) => setAttachSessId(e.target.value)} size="large" />
+        <Row>
+          <Col span={23}>
+            <Select showSearch 
+              notFoundContent='None found'
+              value={attachSessId}
+              onChange={(value) => setAttachSessId(value)}>
+              {runningAppiumSessions.map((session) => <Select.Option key={session.id} value={session.id}>
+                <div>{session.id} -- {formatCaps(session.capabilities)}</div>
+              </Select.Option>)}
+            </Select>
+          </Col>
+          <Col span={1}>
+            <Button onClick={getRunningSessions} icon='reload' />
+          </Col>
+        </Row>
       </FormItem>
     </Form>);
   }

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -13,11 +13,12 @@ const FormItem = Form.Item;
 export default class Session extends Component {
 
   componentWillMount () {
-    const {setLocalServerParams, getSavedSessions, setSavedServerParams} = this.props;
+    const {setLocalServerParams, getSavedSessions, setSavedServerParams, getRunningSessions} = this.props;
     (async function () {
       await getSavedSessions();
       await setSavedServerParams();
       await setLocalServerParams();
+      getRunningSessions();
     })();
   }
 

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -7,6 +7,7 @@ import { NEW_SESSION_REQUESTED, NEW_SESSION_BEGAN, NEW_SESSION_DONE,
         SWITCHED_TABS, SAVE_AS_MODAL_REQUESTED, HIDE_SAVE_AS_MODAL_REQUESTED, SET_SAVE_AS_TEXT,
         DELETE_SAVED_SESSION_REQUESTED, DELETE_SAVED_SESSION_DONE,
         CHANGE_SERVER_TYPE, SET_SERVER_PARAM, SET_SERVER, SET_ATTACH_SESS_ID,
+        GET_SESSIONS_REQUESTED, GET_SESSIONS_DONE,
         ServerTypes } from '../actions/Session';
 
 // Make sure there's always at least one cap
@@ -28,6 +29,8 @@ const INITIAL_STATE = {
   }],
 
   isCapsDirty: true,
+  gettingSessions: false,
+  runningAppiumSessions: [],
 };
 
 let nextState;
@@ -186,6 +189,19 @@ export default function session (state = INITIAL_STATE, action) {
 
     case SESSION_LOADING_DONE:
       return omit(state, 'sessionLoading');
+
+    case GET_SESSIONS_REQUESTED:
+      return {
+        ...state,
+        gettingSessions: true,
+      };
+
+    case GET_SESSIONS_DONE:
+      return {
+        ...state,
+        gettingSessions: false,
+        runningAppiumSessions: action.sessions || [],
+      };
 
     default:
       return {...state};

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -193,7 +193,6 @@ export default function session (state = INITIAL_STATE, action) {
     case GET_SESSIONS_REQUESTED:
       return {
         ...state,
-        attachSessId: undefined,
         gettingSessions: true,
       };
 
@@ -201,7 +200,7 @@ export default function session (state = INITIAL_STATE, action) {
       return {
         ...state,
         gettingSessions: false,
-        attachSessId: (action.sessions && action.sessions.length > 0) ? action.sessions[0].id : undefined,
+        attachSessId: (action.sessions && action.sessions.length > 0 && !state.attachSessId) ? action.sessions[0].id : state.attachSessId,
         runningAppiumSessions: action.sessions || [],
       };
 

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -193,6 +193,7 @@ export default function session (state = INITIAL_STATE, action) {
     case GET_SESSIONS_REQUESTED:
       return {
         ...state,
+        attachSessId: undefined,
         gettingSessions: true,
       };
 
@@ -200,6 +201,7 @@ export default function session (state = INITIAL_STATE, action) {
       return {
         ...state,
         gettingSessions: false,
+        attachSessId: (action.sessions && action.sessions.length > 0) ? action.sessions[0].id : undefined,
         runningAppiumSessions: action.sessions || [],
       };
 


### PR DESCRIPTION
* Instead of having to hardcode session id's, the desktop app gets the list of sessions from /wd/hub/sessions endpoint

![attach session](https://cloud.githubusercontent.com/assets/852574/26227600/77b6f416-3be8-11e7-990c-063e96740d68.png)

(reviewer @jlipps)