### PR TITLE
Catch source/screenshot exceptions and report error to UI

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -295,7 +295,7 @@ function connectClientMethodListener () {
           source = await driver.source();
         } catch (e) {
           if (e.status === 6) {
-            renderer.send('appium-session-done', e);
+            throw e;
           }
           sourceError = e;
         }
@@ -307,7 +307,7 @@ function connectClientMethodListener () {
           screenshot = await driver.takeScreenshot();
         } catch (e) {
           if (e.status === 6) {
-            renderer.send('appium-session-done', e);
+            throw e;
           }
           screenshotError = e;
         }

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -288,10 +288,30 @@ function connectClientMethodListener () {
         // Give method time to finish altering the source before getting source and screenshot
         await Bluebird.delay(500);
 
-        // Send back the new source and screenshot
-        source = await driver.source();
-        screenshot = await driver.takeScreenshot();
-        renderer.send('appium-client-command-response', {source, screenshot, uuid, result});
+        // Try getting the source
+        let source;
+        let sourceError;
+        try {
+          source = await driver.source();
+        } catch (e) {
+          if (e.status === 6) {
+            renderer.send('appium-session-done', e);
+          }
+          sourceError = e;
+        }
+
+        // Try getting the screenshot
+        let screenshot;
+        let screenshotError;
+        try {
+          screenshot = await driver.takeScreenshot();
+        } catch (e) {
+          if (e.status === 6) {
+            renderer.send('appium-session-done', e);
+          }
+          screenshotError = e;
+        }
+        renderer.send('appium-client-command-response', {source, screenshot, uuid, result, sourceError, screenshotError});
       }
 
     } catch (e) {
@@ -299,7 +319,6 @@ function connectClientMethodListener () {
       if (e.status === 6) {
         renderer.send('appium-session-done', e);
       }
-      console.log('reporting error', {e, uuid});
       renderer.send('appium-client-command-response-error', {e, uuid});
     }
   });

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -5,7 +5,7 @@ import { showError } from './Session';
 import { callClientMethod } from './shared';
 import { getOptimalXPath } from '../util';
 
-export const SET_SOURCE_AND_SCREENSHOT = 'SET_SOURCE';
+export const SET_SOURCE_AND_SCREENSHOT = 'SET_SOURCE_AND_SCREENSHOT';
 export const SESSION_DONE = 'SESSION_DONE';
 export const SELECT_ELEMENT = 'SELECT_ELEMENT';
 export const UNSELECT_ELEMENT = 'UNSELECT_ELEMENT';
@@ -119,9 +119,9 @@ export function applyClientMethod (params) {
   return async (dispatch) => {
     try {
       dispatch({type: METHOD_CALL_REQUESTED});
-      let {source, screenshot, result} = await callClientMethod(params.methodName, params.args, params.xpath);
+      let {source, screenshot, result, sourceError, screenshotError} = await callClientMethod(params.methodName, params.args, params.xpath);
       dispatch({type: METHOD_CALL_DONE});
-      dispatch({type: SET_SOURCE_AND_SCREENSHOT, source: xmlToJSON(source), screenshot});
+      dispatch({type: SET_SOURCE_AND_SCREENSHOT, source: source && xmlToJSON(source), screenshot, sourceError, screenshotError});
       return result;
     } catch (error) {
       let methodName = params.methodName === 'click' ? 'tap' : params.methodName;

--- a/app/renderer/actions/shared.js
+++ b/app/renderer/actions/shared.js
@@ -11,10 +11,10 @@ if (ipcRenderer) {
    * When we hear back from the main process, resolve the promise
    */
   ipcRenderer.on('appium-client-command-response', (evt, resp) => {
-    const {source, screenshot, result, uuid} = resp;
+    const {source, screenshot, result, screenshotError, sourceError, uuid} = resp;
     let promise = clientMethodPromises[uuid];
     if (promise) {
-      promise.resolve({source, screenshot, result});
+      promise.resolve({source, screenshot, result, screenshotError, sourceError});
       delete clientMethodPromises[uuid];
     }
   });

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -27,7 +27,7 @@ export default class Inspector extends Component {
   }
 
   render () {
-    const {screenshot, selectedElement = {}, applyClientMethod, quitSession} = this.props;
+    const {screenshot, screenshotError, selectedElement = {}, applyClientMethod, quitSession} = this.props;
     const {path} = selectedElement;
 
     let actions = <span>
@@ -45,7 +45,8 @@ export default class Inspector extends Component {
     return <div className={InspectorStyles['inspector-container']}>
       <div className={InspectorStyles['screenshot-container']}>
         {screenshot && <Screenshot {...this.props} />}
-        {!screenshot &&
+        {screenshotError && `Could not obtain screenshot: ${screenshotError}`}
+        {!screenshot && !screenshotError &&
           <Spin size="large" spinning={true}>
             <div className={InspectorStyles.screenshotBox} />
           </Spin>

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -50,7 +50,7 @@ export default class Source extends Component {
   }
 
   render () {
-    const {source, setExpandedPaths, expandedPaths, selectedElement = {}} = this.props;
+    const {source, sourceError, setExpandedPaths, expandedPaths, selectedElement = {}} = this.props;
     const {path} = selectedElement;
 
     // Recursives through the source and renders a TreeNode for an element
@@ -75,8 +75,11 @@ export default class Source extends Component {
           {recursive(source)}
         </Tree>
       }
-      {!source &&
+      {!source && !sourceError &&
         <i>Gathering initial app source...</i>
+      }
+      {
+        sourceError && `Could not obtain source: ${sourceError}`
       }
     </div>;
   }

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -24,7 +24,9 @@ export default function inspector (state=INITIAL_STATE, action) {
       return {
         ...state,
         source: action.source,
+        sourceError: action.sourceError,
         screenshot: action.screenshot,
+        screenshotError: action.screenshotError,
       };
 
     case QUIT_SESSION_REQUESTED:
@@ -71,7 +73,10 @@ export default function inspector (state=INITIAL_STATE, action) {
       };
 
     case METHOD_CALL_DONE:
-      return omit(state, 'methodCallInProgress');
+      return {
+        ...state,
+        methodCallInProgress: false,
+      };
 
     case SET_FIELD_VALUE:
       return {


### PR DESCRIPTION
* Added more try-catch blocks to appium.js thread so that if the source and screenshot fails it still continues but just reports the sourceError and screenshotError to the running browser window
* Added sourceError and screenshotError to the store
* If sourceError or screenshotError is present, show an error message in place of where source and screenshot go