### PR TITLE
only resize inspector if it was previously too small

### DIFF
--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -10,6 +10,9 @@ import RecordedActions from './RecordedActions';
 
 const ButtonGroup = Button.Group;
 
+const MIN_WIDTH = 1080;
+const MIN_HEIGHT = 570;
+
 export default class Inspector extends Component {
 
   constructor () {
@@ -19,12 +22,16 @@ export default class Inspector extends Component {
   }
 
   componentWillMount () {
-    const chromeHeight = 48;
-    if (!this.didInitialResize) {
+    const curHeight = window.innerHeight;
+    const curWidth = window.innerWidth;
+    const needsResize = (curHeight < MIN_HEIGHT) || (curWidth < MIN_WIDTH);
+    if (!this.didInitialResize && needsResize) {
+      const newWidth = curWidth < MIN_WIDTH ? MIN_WIDTH : curWidth;
+      const newHeight = curHeight < MIN_HEIGHT ? MIN_HEIGHT : curHeight;
       // resize width to something sensible for using the inspector on first run
-      window.resizeTo(1080, window.clientHeight - chromeHeight);
-      this.didInitialResize = true;
+      window.resizeTo(newWidth, newHeight);
     }
+    this.didInitialResize = true;
     this.props.bindAppium();
     this.props.applyClientMethod({methodName: 'source'});
     this.props.getSavedActionFramework();


### PR DESCRIPTION
this was kind of annoying; i noticed that when i had the new session window already open large, the inspector would be resized small. fix that.