### PR TITLE
Refactor mocha tests to use es6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "main.js",
   "scripts": {
     "test": "npm run unit-test",
-    "e2e": "mocha ./test/e2e",
+    "e2e": "mocha --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/e2e",
     "unit-test": "mocha --compilers js:babel-core/register ./test/unit",
     "lint": "eslint app test *.js",
     "hot-server": "node -r babel-register server.js --color",
@@ -126,6 +126,7 @@
     "xpath": "0.0.24"
   },
   "devDependencies": {
+    "appium-fake-driver": "^0.1.11",
     "asar": "0.x",
     "babel-core": "6.x",
     "babel-eslint": "7.x",

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -1,0 +1,21 @@
+import { Application } from  'spectron';
+import assert from 'assert';
+import os from 'os';
+import path from 'path';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const platform = os.platform();
+
+describe('inspector window', function () {
+  beforeEach(function () {
+
+  });
+
+  it('shows an initial window', function () {
+    true.should.equal(true);
+  });
+});

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -1,56 +1,52 @@
-var Application = require('spectron').Application;
-var assert = require('assert');
-var os = require('os');
-var platform = os.platform();
-var path = require('path');
+import { Application } from  'spectron';
+import os from 'os';
+import path from 'path';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+const platform = os.platform();
+
+chai.should();
+chai.use(chaiAsPromised);
+
+let appPath;
+if (platform === 'linux') {
+  appPath = path.join(__dirname, '..', '..', 'release', 'linux-unpacked', 'appium-desktop');
+} else if (platform === 'darwin') {
+  appPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'MacOS', 'Appium');
+} else if (platform === 'win32') {
+  appPath = path.join(__dirname, '..', '..', 'release', 'win-ia32-unpacked', 'Appium.exe');
+}
+
+before(function () {
+  this.timeout(process.env.TRAVIS || process.env.APPVEYOR ? 10 * 60 * 1000 : 30 * 1000);
+  this.app = new Application({
+    path: appPath,
+  });
+  return this.app.start();
+});
+
+after(function () {
+  if (this.app && this.app.isRunning()) {
+    return this.app.stop();
+  }
+});
 
 describe('application launch', function () {
-  this.timeout(process.env.TRAVIS || process.env.APPVEYOR ? 10 * 60 * 1000 : 30 * 1000);
-
-  var appPath;
-  if (platform === 'linux') {
-    appPath = path.join(__dirname, '..', '..', 'release', 'linux-unpacked', 'appium-desktop');
-  } else if (platform === 'darwin') {
-    appPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'MacOS', 'Appium');
-  } else if (platform === 'win32') {
-    appPath = path.join(__dirname, '..', '..', 'release', 'win-ia32-unpacked', 'Appium.exe');
-  }
-
-  beforeEach(function () {
-    this.app = new Application({
-      path: appPath,
-    });
-    return this.app.start();
+  it('shows an initial window', async function () {
+    await this.app.client.getWindowCount().should.eventually.equal(1);
   });
 
-  afterEach(function () {
-    if (this.app && this.app.isRunning()) {
-      return this.app.stop();
-    }
-  });
-
-  it('shows an initial window', function () {
-    return this.app.client.getWindowCount().then(function (count) {
-      assert.equal(count, 1);
-    });
-  });
-
-  it('starts the server and opens a new session window', function (done) {
+  it('starts the server and opens a new session window', async function () {
     var client = this.app.client;
-    client.waitForExist('form button.ant-btn-primary');
+    await client.waitForExist('form button.ant-btn-primary');
     var startServerBtn = client.element('form button.ant-btn-primary');
     startServerBtn.click();
-    client.waitForExist('div[class^="ServerMonitor"]').then(function () {
-      client.source().then(function (source) {
-        assert.equal(source.value.indexOf('Welcome to Appium') >= 0, true);
-        client.element('*[class*="button-container"] button').click();
-        client.pause(500).then(function () {
-          client.getWindowCount().then(function (count) {
-            assert.equal(count, 2);
-            done();
-          });
-        });
-      });
-    });
+    await client.waitForExist('div[class^="ServerMonitor"]');
+    const source = await client.source();
+    source.value.indexOf('Welcome to Appium').should.be.above(0);
+    client.element('*[class*="button-container"] button').click();
+    await client.pause(500);
+    await client.getWindowCount().should.eventually.equal(2);
   });
 });


### PR DESCRIPTION
* Transpiles mocha e2e tests using babel
* Refactor tests in main-e2e.test.js to use async/await, const, etc...
* Stubbed in inspector-e2e.test.js (later PR will have full tests)
* Doesn't restart the app after every test suite any more (was too slow)