### PR TITLE
Added inspector tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,28 @@ npm run build  # prepare resources
 npm start  # start a production version of the app
 ```
 
+### Running tests
+
+To run unit tests, run the command
+
+```bash
+npm test
+```
+
+Before running e2e tests, run the command
+
+```bash
+npm run package-e2e-test
+```
+
+This will create builds in the `release/` folder that are specific for e2e testing. This only needs to be run whenever you make changes to the application.
+
+To run the e2e tests call 
+
+```bash
+npm run e2e
+```
+
 ### Packaging and Releasing
 
 Appium Desktop uses [Electron Builder](https://github.com/electron-userland/electron-builder/) to build app. Read this document for instructions on how to set up your local environment so that you can build and package the app: https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -43,7 +43,7 @@ export default class Inspector extends Component {
       pauseRecording} = this.props;
     const {path} = selectedElement;
 
-    let main = <div className={InspectorStyles['inspector-main']}>
+    let main = <div id='screenshotContainer' className={InspectorStyles['inspector-main']}>
       <div className={InspectorStyles['screenshot-container']}>
         {screenshot && <Screenshot {...this.props} />}
         {screenshotError && `Could not obtain screenshot: ${screenshotError}`}
@@ -64,7 +64,7 @@ export default class Inspector extends Component {
         </Card>
         {this.container && <SourceScrollButtons container={this.container} />}
       </div>
-      <div className={`${InspectorStyles['source-tree-container']} ${InspectorStyles['element-detail-container']}`}>
+      <div id='selectedElementContainer' className={`${InspectorStyles['source-tree-container']} ${InspectorStyles['element-detail-container']}`}>
         <Card
          title={<span><Icon type="tag-o" /> Selected Element</span>}
          className={InspectorStyles['selected-element-card']}>
@@ -77,23 +77,23 @@ export default class Inspector extends Component {
     let controls = <div className={InspectorStyles['inspector-toolbar']}>
       <ButtonGroup size="large">
         <Tooltip title="Back">
-          <Button icon='arrow-left' onClick={() => applyClientMethod({methodName: 'back'})}/>
+          <Button id='btnGoBack' icon='arrow-left' onClick={() => applyClientMethod({methodName: 'back'})}/>
         </Tooltip>
         <Tooltip title="Refresh Source & Screenshot">
-          <Button icon='reload' onClick={() => applyClientMethod({methodName: 'source'})}/>
+          <Button id='btnReload' icon='reload' onClick={() => applyClientMethod({methodName: 'source'})}/>
         </Tooltip>
         {!isRecording &&
          <Tooltip title="Start Recording">
-          <Button icon="eye-o" onClick={startRecording}/>
+          <Button id='btnStartRecording' icon="eye-o" onClick={startRecording}/>
          </Tooltip>
         }
         {isRecording &&
          <Tooltip title="Pause Recording">
-           <Button icon="pause" type="danger" onClick={pauseRecording}/>
+           <Button id='btnPause' icon="pause" type="danger" onClick={pauseRecording}/>
          </Tooltip>
         }
         <Tooltip title="Quit Session & Close Inspector">
-          <Button icon='close' onClick={() => quitSession()}/>
+          <Button id='btnClose' icon='close' onClick={() => quitSession()}/>
         </Tooltip>
       </ButtonGroup>
     </div>;

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -100,9 +100,9 @@ export default class SelectedElement extends Component {
       <Row justify="center" type="flex" align="middle" gutter={10} className={styles.elementActions}>
         <Col>
           <ButtonGroup size="small">
-            <Button onClick={() => applyClientMethod({methodName: 'click', xpath})}>Tap</Button>
-            <Button onClick={() => showSendKeysModal()}>Send Keys</Button>
-            <Button onClick={() => applyClientMethod({methodName: 'clear', xpath})}>Clear</Button>
+            <Button id='btnTapElement' onClick={() => applyClientMethod({methodName: 'click', xpath})}>Tap</Button>
+            <Button id='btnSendKeysToElement' onClick={() => showSendKeysModal()}>Send Keys</Button>
+            <Button id='btnClearElement' onClick={() => applyClientMethod({methodName: 'clear', xpath})}>Clear</Button>
           </ButtonGroup>
         </Col>
       </Row>

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -65,7 +65,7 @@ export default class Source extends Component {
       });
     };
 
-    return <div className={InspectorStyles['tree-container']}>
+    return <div id='sourceContainer' className={InspectorStyles['tree-container']}>
       {source &&
         <Tree onExpand={setExpandedPaths}
           autoExpandParent={false}

--- a/app/renderer/components/ServerMonitor/ServerMonitor.js
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.js
@@ -53,7 +53,7 @@ class StartSessionButton extends Component {
   render () {
     const {serverStatus, startSession} = this.props;
     if (serverStatus !== STATUS_STOPPED && serverStatus !== STATUS_STOPPING) {
-      return <Button className={styles.stopButton}
+      return <Button className={styles.stopButton} id='startNewSessionBtn'
               icon="play-circle-o"
              onClick={startSession}>Start New Session</Button>;
     } else {
@@ -134,7 +134,7 @@ export default class ServerMonitor extends Component {
 
 
     return (
-      <div className={styles.container}>
+      <div className={styles.container} id='serverMonitorContainer'>
         <div className={`${styles.bar} ${styles['bar-'+serverStatus]}`}>
           <img src={'images/appium_small_magenta.png'} className={styles.logo} />
           <div className={`${styles.status} ${styles[serverStatus]}`}>

--- a/app/renderer/components/Session/NewSessionForm.js
+++ b/app/renderer/components/Session/NewSessionForm.js
@@ -26,15 +26,15 @@ export default class NewSessionForm extends Component {
       onClick={() => this.getLocalFilePath((filepath) => setCapabilityParam(index, 'value', filepath[0]))} />;
 
     switch (cap.type) {
-      case 'text': return <Input placeholder='Value' value={cap.value} onChange={(e) => setCapabilityParam(index, 'value', e.target.value)} size="large"/>;
-      case 'boolean': return <Switch checkedChildren={'true'} unCheckedChildren={'false'}
+      case 'text': return <Input id={`desiredCapabilityValue_${index}`} placeholder='Value' value={cap.value} onChange={(e) => setCapabilityParam(index, 'value', e.target.value)} size="large"/>;
+      case 'boolean': return <Switch id={`desiredCapabilityValue_${index}`} checkedChildren={'true'} unCheckedChildren={'false'}
         placeholder='Value' checked={cap.value} onChange={(value) => setCapabilityParam(index, 'value', value)} />;
-      case 'number': return <Input placeholder='Value' value={cap.value}
+      case 'number': return <Input id={`desiredCapabilityValue_${index}`} placeholder='Value' value={cap.value}
         onChange={(e) => !isNaN(parseInt(e.target.value, 10)) ? setCapabilityParam(index, 'value', parseInt(e.target.value, 10)) : setCapabilityParam(index, 'value', undefined)} size="large"/>;
-      case 'json_object': return <Input type='textarea' rows={4} placeholder='Value' value={cap.value}
+      case 'json_object': return <Input id={`desiredCapabilityValue_${index}`} type='textarea' rows={4} placeholder='Value' value={cap.value}
         onChange={(e) => setCapabilityParam(index, 'value', e.target.value)} size="large"/>;
       case 'file': return <div className={SessionStyles.fileControlWrapper}>
-        <Input placeholder='Value' value={cap.value} addonAfter={buttonAfter} size="large"/>
+        <Input id={`desiredCapabilityValue_${index}`} placeholder='Value' value={cap.value} addonAfter={buttonAfter} size="large"/>
       </div>;
       default:
         throw `Invalid cap type: ${cap.type}`;
@@ -88,7 +88,7 @@ export default class NewSessionForm extends Component {
           {caps.map((cap, index) => {
             return <div key={index} className={SessionStyles['desired-capabilities-form-container']}>
               <FormItem>
-                <Input placeholder='Name' value={cap.name} onChange={(e) => setCapabilityParam(index, 'name', e.target.value)}/>
+                <Input id={`desiredCapabilityName_${index}`} placeholder='Name' value={cap.name} onChange={(e) => setCapabilityParam(index, 'name', e.target.value)}/>
               </FormItem>
               <FormItem>
                 <Select onChange={(val) => this.handleSetType(index, val)} defaultValue={cap.type} size="large" style={{width: 120}}>
@@ -103,13 +103,13 @@ export default class NewSessionForm extends Component {
                 {this.getCapsControl(cap, index)}
               </FormItem>
               <FormItem>
-                <Button {...{disabled: caps.length <= 1}} icon='delete' onClick={() => removeCapability(index)}/>
+                <Button {...{disabled: caps.length <= 1}} icon='delete' onClick={() => remove(index)}/>
               </FormItem>
             </div>;
           })}
           <div className={SessionStyles.capsFormLastRow}>
             <FormItem>
-              <Button icon='plus' onClick={addCapability} className={SessionStyles['add-desired-capability-button']} />
+              <Button id='btnAddDesiredCapability' icon='plus' onClick={addCapability} className={SessionStyles['add-desired-capability-button']} />
             </FormItem>
           </div>
         </Form>

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -103,7 +103,9 @@ export default class Session extends Component {
           </div>
           { (!isAttaching && capsUUID) && <Button onClick={() => saveSession(caps, {uuid: capsUUID})} disabled={!isCapsDirty}>Save</Button> }
           {!isAttaching && <Button onClick={requestSaveAsModal}>Save As...</Button>}
-          {!isAttaching && <Button type="primary" onClick={() => newSession(caps)} className={SessionStyles['start-session-button']}>Start Session</Button>}
+          {!isAttaching && <Button type="primary" id='btnStartSession' 
+            onClick={() => newSession(caps)} className={SessionStyles['start-session-button']}>Start Session</Button>
+          }
           {isAttaching &&
             <Button type="primary" disabled={!attachSessId} onClick={() => newSession(null, attachSessId)}>
               Attach to Session

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -35,46 +35,48 @@ export default class Session extends Component {
 
     return <Spin spinning={!!sessionLoading}>
       <div className={SessionStyles['session-container']}>
-        <Tabs activeKey={serverType} onChange={changeServerType} className={SessionStyles.serverTabs}>
-          <TabPane disabled={!server.local.port} tab='Automatic Server' key={ServerTypes.local}>
-            <Form>
-              <FormItem>
-                <Card>
-                  {server.local.port && <p className={SessionStyles.localDesc}>Will use currently-running Appium Desktop server at
-                    <b> http://{server.local.hostname === "0.0.0.0" ? "localhost" : server.local.hostname}:{server.local.port}</b>
-                  </p>}
-                </Card>
-              </FormItem>
-            </Form>
-          </TabPane>
-          <TabPane tab='Custom Server' key={ServerTypes.remote}>
-            <Form>
-              <FormItem>
-                <Input placeholder='127.0.0.1' addonBefore="Remote Host" value={server.remote.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} size="large" />
-              </FormItem>
-              <FormItem>
-                <Input placeholder='4723' addonBefore="Remote Port" value={server.remote.port} onChange={(e) => setServerParam('port', e.target.value)} size="large" />
-              </FormItem>
-            </Form>
-          </TabPane>
-          <TabPane tab={sauceTabHead} key={ServerTypes.sauce}>
-            <Form>
-              <FormItem>
-                <Input placeholder={process.env.SAUCE_USERNAME ? 'Using data found in $SAUCE_USERNAME' : 'your-username'} addonBefore="Sauce Username" value={server.sauce.username} onChange={(e) => setServerParam('username', e.target.value)} />
-              </FormItem>
-              <FormItem>
-                <Input type='password' placeholder={process.env.SAUCE_ACCESS_KEY ? 'Using data found in $SAUCE_ACCESS_KEY' : 'your-access-key'} addonBefore="Sauce Access Key" value={server.sauce.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-              </FormItem>
-            </Form>
-          </TabPane>
-          <TabPane tab={testObjectTabHead} key={ServerTypes.testobject}>
-            <Form>
-              <FormItem>
-                <Input type='password' placeholder={process.env.TESTOBJECT_API_KEY ? 'Using data found in $TESTOBJECT_API_KEY' : 'testobject-api-key'} addonBefore="TestObject API Key" value={server.testobject.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} />
-              </FormItem>
-            </Form>
-          </TabPane>
-        </Tabs>
+        <div id='serverTypeTabs'>
+          <Tabs activeKey={serverType} onChange={changeServerType} className={SessionStyles.serverTabs}>
+            <TabPane disabled={!server.local.port} tab='Automatic Server' key={ServerTypes.local}>
+              <Form>
+                <FormItem>
+                  <Card>
+                    {server.local.port && <p className={SessionStyles.localDesc}>Will use currently-running Appium Desktop server at
+                      <b> http://{server.local.hostname === "0.0.0.0" ? "localhost" : server.local.hostname}:{server.local.port}</b>
+                    </p>}
+                  </Card>
+                </FormItem>
+              </Form>
+            </TabPane>
+            <TabPane tab='Custom Server' key={ServerTypes.remote}>
+              <Form>
+                <FormItem>
+                  <Input id='customServerHost' placeholder='127.0.0.1' addonBefore="Remote Host" value={server.remote.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} size="large" />
+                </FormItem>
+                <FormItem>
+                  <Input id='customServerPort' placeholder='4723' addonBefore="Remote Port" value={server.remote.port} onChange={(e) => setServerParam('port', e.target.value)} size="large" />
+                </FormItem>
+              </Form>
+            </TabPane>
+            <TabPane tab={sauceTabHead} key={ServerTypes.sauce}>
+              <Form>
+                <FormItem>
+                  <Input id='sauceUsername' placeholder={process.env.SAUCE_USERNAME ? 'Using data found in $SAUCE_USERNAME' : 'your-username'} addonBefore="Sauce Username" value={server.sauce.username} onChange={(e) => setServerParam('username', e.target.value)} />
+                </FormItem>
+                <FormItem>
+                  <Input id='saucePassword' type='password' placeholder={process.env.SAUCE_ACCESS_KEY ? 'Using data found in $SAUCE_ACCESS_KEY' : 'your-access-key'} addonBefore="Sauce Access Key" value={server.sauce.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+                </FormItem>
+              </Form>
+            </TabPane>
+            <TabPane tab={testObjectTabHead} key={ServerTypes.testobject}>
+              <Form>
+                <FormItem>
+                  <Input id='testObjectPassword' type='password' placeholder={process.env.TESTOBJECT_API_KEY ? 'Using data found in $TESTOBJECT_API_KEY' : 'testobject-api-key'} addonBefore="TestObject API Key" value={server.testobject.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} />
+                </FormItem>
+              </Form>
+            </TabPane>
+          </Tabs>
+        </div>
 
 
         {newSessionBegan && <div key={2}>

--- a/app/renderer/components/StartServer/StartButton.js
+++ b/app/renderer/components/StartServer/StartButton.js
@@ -27,7 +27,7 @@ export default class StartButton extends Component {
 
     return (
       <div>
-        <Button {...buttonProps}
+        <Button {...buttonProps} id='startServerBtn'
          className={styles.startButton}
          type="primary"
          onClick={this.isEnabled() ? startServer : this.noop}

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "package-win": "npm run build && build --win --x64",
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
-    "package-ci": "npm run build && build --dir && npm run e2e && build --publish onTagOrDraft",
-    "package-dir": "npm run build && build --dir",
+    "package-e2e-test": "npm run build && build --dir",
+    "package-ci": "npm run build && npm run package-e2e-test && npm run e2e && build --publish onTagOrDraft",
     "postversion": "git pull --tags && git push && git push --tags"
   },
   "build": {
@@ -129,6 +129,7 @@
   "devDependencies": {
     "appium-fake-driver": "^0.1.11",
     "asar": "0.x",
+    "asyncbox": "^2.3.1",
     "babel-core": "6.x",
     "babel-eslint": "7.x",
     "babel-loader": "6.x",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "main.js",
   "scripts": {
     "test": "npm run unit-test",
-    "e2e": "mocha --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/e2e",
+    "e2e": "mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/e2e",
     "unit-test": "mocha --compilers js:babel-core/register ./test/unit",
     "lint": "eslint app test *.js",
     "hot-server": "node -r babel-register server.js --color",
@@ -40,6 +40,7 @@
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
     "package-ci": "npm run build && build --dir && npm run e2e && build --publish onTagOrDraft",
+    "package-dir": "npm run build && build --dir",
     "postversion": "git pull --tags && git push && git push --tags"
   },
   "build": {

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -44,14 +44,11 @@ describe('inspector window', function () {
 
     // Set the desired capabilities
     await client.waitForExist('#btnAddDesiredCapability');
-    for (let i=0; i<dcaps.length - 1; i++) {
-      await client.click('#btnAddDesiredCapability');
-    }
-    let i =0;
-    for (let [name, value] of dcaps) {
+    for (let i = 0; i < dcaps.length; i++) {
+      const [name, value] = dcaps[i];
       await client.setValue(`#desiredCapabilityName_${i}`, name);
       await client.setValue(`#desiredCapabilityValue_${i}`, value);
-      i++;
+      await client.click('#btnAddDesiredCapability');
     }
 
     // Set the fake driver server and port

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -1,21 +1,58 @@
-import { Application } from  'spectron';
-import assert from 'assert';
-import os from 'os';
 import path from 'path';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import { startServer as startAppiumFakeDriverServer } from 'appium-fake-driver';
+import _ from 'lodash';
+import B from 'bluebird';
 
 chai.should();
 chai.use(chaiAsPromised);
 
-const platform = os.platform();
+const FAKE_DRIVER_PORT = 12121;
+
+const TEST_APP = path.resolve('..', '..', 'node_modules', 'appium-fake-driver', 'test', 'fixtures', 'app.xml');
+
+const DEFAULT_CAPS = {
+  platformName: 'Fake',
+  deviceName: 'Fake',
+  app: TEST_APP,
+};
+
+const dcaps = _.toPairs(DEFAULT_CAPS);
+
+let client;
 
 describe('inspector window', function () {
-  beforeEach(function () {
+  before(async function () {
+    // Start an Appium fake driver server
+    startAppiumFakeDriverServer(FAKE_DRIVER_PORT, '127.0.0.1');
 
+    // Navigate to session URL
+    client = this.app.client;
+    const currentUrl = await client.url();
+    await client.url(currentUrl.value + 'session');
+
+    // Add three dcaps to the row
+    await client.waitForExist('#btnAddDesiredCapability');
+    for (let i=0; i<dcaps.length - 1; i++) {
+      await client.click('#btnAddDesiredCapability');
+    }
+    let i =0;
+    for (let [name, value] of dcaps) {
+      await client.setValue(`#desiredCapabilityName_${i}`, name);
+      await client.setValue(`#desiredCapabilityValue_${i}`, value);
+      i++;
+    }
+
+    // Set the fake driver server and port
+    await client.setValue('#customServerHost', '127.0.0.1');
+    await client.setValue('#customServerPort', FAKE_DRIVER_PORT);
+
+    // Start the session
+    await client.click('.ant-btn-primary');
   });
 
-  it('shows an initial window', function () {
-    true.should.equal(true);
+  it('starts a fake driver session', async function () {
+    
   });
 });

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -3,14 +3,14 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { startServer as startAppiumFakeDriverServer } from 'appium-fake-driver';
 import _ from 'lodash';
-import B from 'bluebird';
+import { retryInterval } from 'asyncbox';
 
 chai.should();
 chai.use(chaiAsPromised);
 
 const FAKE_DRIVER_PORT = 12121;
 
-const TEST_APP = path.resolve('..', '..', 'node_modules', 'appium-fake-driver', 'test', 'fixtures', 'app.xml');
+const TEST_APP = path.resolve('node_modules', 'appium-fake-driver', 'test', 'fixtures', 'app.xml');
 
 const DEFAULT_CAPS = {
   platformName: 'Fake',
@@ -21,6 +21,15 @@ const DEFAULT_CAPS = {
 const dcaps = _.toPairs(DEFAULT_CAPS);
 
 let client;
+let defaultUrl;
+
+async function closeNotification (client) {
+  try {
+    await retryInterval(5, 500, () => {
+      client.click('.ant-notification-notice-close');
+    });
+  } catch (ign) { }
+}
 
 describe('inspector window', function () {
   before(async function () {
@@ -29,10 +38,11 @@ describe('inspector window', function () {
 
     // Navigate to session URL
     client = this.app.client;
-    const currentUrl = await client.url();
-    await client.url(currentUrl.value + 'session');
+    const url = await client.url();
+    defaultUrl = url.value;
+    await client.url(defaultUrl + 'session');
 
-    // Add three dcaps to the row
+    // Set the desired capabilities
     await client.waitForExist('#btnAddDesiredCapability');
     for (let i=0; i<dcaps.length - 1; i++) {
       await client.click('#btnAddDesiredCapability');
@@ -52,7 +62,45 @@ describe('inspector window', function () {
     await client.click('.ant-btn-primary');
   });
 
-  it('starts a fake driver session', async function () {
-    
+  after(async function () {
+    await client.waitForExist('#btnClose');
+    await client.click('#btnClose');
+    await client.url(defaultUrl);
+  });
+
+  beforeEach(async function () {
+    await client.waitForExist('div[class*=Inspector__inspector-toolbar]');
+  });
+
+  it('shows content in "Selected Element" pane when clicking on an item in the Source inspector', async function () {
+    await client.getHTML('#selectedElementContainer .ant-card-body').should.eventually.contain('Select an element');
+    await client.waitForExist('#sourceContainer .ant-tree-node-content-wrapper');
+    await client.click('#sourceContainer .ant-tree-node-content-wrapper');
+    await client.waitForExist('#selectedElementContainer #btnTapElement');
+    await client.getHTML('#selectedElementContainer .ant-card-body').should.eventually.contain('btnTapElement');
+    await client.click('#selectedElementContainer #btnTapElement');
+    await closeNotification();
+  });
+
+  it('shows a loading indicator in screenshot afterwhen clicking "Refresh" and then indicator goes away when refresh is complete', async function () {
+    await client.click('#btnReload');
+    const spinDots = await client.elements('#screenshotContainer .ant-spin-dot');
+    spinDots.value.length.should.equal(1);
+    await retryInterval(15, 100, async () => {
+      const spinDots = await client.elements('#screenshotContainer .ant-spin-dot');
+      spinDots.value.length.should.equal(0);
+    });
+  });
+
+  it('shows a new pane when click "Start Recording" button and then the pane disappears when clicking "Pause"', async function () {
+    let recordedPanes = await client.elements('div[class*=Inspector__recorded-actions]');
+    recordedPanes.value.length.should.equal(0);
+    await client.click('#btnStartRecording');
+    await client.waitForExist('div[class*=Inspector__recorded-actions]');
+    recordedPanes = await client.elements('div[class*=Inspector__recorded-actions]');
+    recordedPanes.value.length.should.equal(1);
+    await client.click('#btnPause');
+    recordedPanes = await client.elements('div[class*=Inspector__recorded-actions]');
+    recordedPanes.value.length.should.equal(0);
   });
 });

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -2,8 +2,8 @@ import path from 'path';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { startServer as startAppiumFakeDriverServer } from 'appium-fake-driver';
-import _ from 'lodash';
 import { retryInterval } from 'asyncbox';
+import InspectorPage from './pages/inspector-page-object';
 
 chai.should();
 chai.use(chaiAsPromised);
@@ -18,86 +18,75 @@ const DEFAULT_CAPS = {
   app: TEST_APP,
 };
 
-const dcaps = _.toPairs(DEFAULT_CAPS);
-
 let client;
-let defaultUrl;
-
-async function closeNotification (client) {
-  try {
-    await retryInterval(5, 500, () => {
-      client.click('.ant-notification-notice-close');
-    });
-  } catch (ign) { }
-}
 
 describe('inspector window', function () {
+
+  let InspectorPageObject;
+  
   before(async function () {
     // Start an Appium fake driver server
     startAppiumFakeDriverServer(FAKE_DRIVER_PORT, '127.0.0.1');
 
     // Navigate to session URL
     client = this.app.client;
-    const url = await client.url();
-    defaultUrl = url.value;
-    await client.url(defaultUrl + 'session');
+    InspectorPageObject = new InspectorPage(client);
+    InspectorPageObject.open('session');
 
     // Set the desired capabilities
-    await client.waitForExist('#btnAddDesiredCapability');
-    for (let i = 0; i < dcaps.length; i++) {
-      const [name, value] = dcaps[i];
-      await client.setValue(`#desiredCapabilityName_${i}`, name);
-      await client.setValue(`#desiredCapabilityValue_${i}`, value);
-      await client.click('#btnAddDesiredCapability');
-    }
+    await client.waitForExist(InspectorPageObject.addDesiredCapabilityButton);
+    await InspectorPageObject.addDCaps(DEFAULT_CAPS);
 
     // Set the fake driver server and port
-    await client.setValue('#customServerHost', '127.0.0.1');
-    await client.setValue('#customServerPort', FAKE_DRIVER_PORT);
+    await InspectorPageObject.setCustomServerHost('127.0.0.1');
+    await InspectorPageObject.setCustomServerPort(FAKE_DRIVER_PORT);
 
     // Start the session
-    await client.click('.ant-btn-primary');
+    await InspectorPageObject.startSession();
   });
 
   after(async function () {
-    await client.waitForExist('#btnClose');
-    await client.click('#btnClose');
-    await client.url(defaultUrl);
+    await InspectorPageObject.goHome();
   });
 
   beforeEach(async function () {
-    await client.waitForExist('div[class*=Inspector__inspector-toolbar]');
+    await client.waitForExist(InspectorPageObject.inspectorToolbar);
   });
 
   it('shows content in "Selected Element" pane when clicking on an item in the Source inspector', async function () {
-    await client.getHTML('#selectedElementContainer .ant-card-body').should.eventually.contain('Select an element');
-    await client.waitForExist('#sourceContainer .ant-tree-node-content-wrapper');
-    await client.click('#sourceContainer .ant-tree-node-content-wrapper');
-    await client.waitForExist('#selectedElementContainer #btnTapElement');
-    await client.getHTML('#selectedElementContainer .ant-card-body').should.eventually.contain('btnTapElement');
-    await client.click('#selectedElementContainer #btnTapElement');
-    await closeNotification();
+    await client.getHTML(InspectorPageObject.selectedElementBody).should.eventually.contain('Select an element');
+    await client.waitForExist(InspectorPageObject.sourceTreeNode);
+    await client.click(InspectorPageObject.sourceTreeNode);
+    await client.waitForExist(InspectorPageObject.tapSelectedElementButton);
+    await client.getHTML(InspectorPageObject.selectedElementBody).should.eventually.contain('btnTapElement');
+    await client.click(InspectorPageObject.tapSelectedElementButton);
+    await InspectorPageObject.closeNotification();
   });
 
-  it('shows a loading indicator in screenshot afterwhen clicking "Refresh" and then indicator goes away when refresh is complete', async function () {
-    await client.click('#btnReload');
-    const spinDots = await client.elements('#screenshotContainer .ant-spin-dot');
+  it('shows a loading indicator in screenshot after clicking "Refresh" and then indicator goes away when refresh is complete', async function () {
+    await InspectorPageObject.reload();
+    const spinDots = await client.elements(InspectorPageObject.screenshotLoadingIndicator);
     spinDots.value.length.should.equal(1);
     await retryInterval(15, 100, async () => {
-      const spinDots = await client.elements('#screenshotContainer .ant-spin-dot');
+      const spinDots = await client.elements(InspectorPageObject.screenshotLoadingIndicator);
       spinDots.value.length.should.equal(0);
     });
   });
 
   it('shows a new pane when click "Start Recording" button and then the pane disappears when clicking "Pause"', async function () {
-    let recordedPanes = await client.elements('div[class*=Inspector__recorded-actions]');
+    // Check that there's no recorded actions pane
+    let recordedPanes = await client.elements(InspectorPageObject.recordedActionsPane);
     recordedPanes.value.length.should.equal(0);
-    await client.click('#btnStartRecording');
-    await client.waitForExist('div[class*=Inspector__recorded-actions]');
-    recordedPanes = await client.elements('div[class*=Inspector__recorded-actions]');
+
+    // Start a recording and check that there is a recorded actions pane
+    await InspectorPageObject.startRecording();
+    await client.waitForExist(InspectorPageObject.recordedActionsPane);
+    recordedPanes = await client.elements(InspectorPageObject.recordedActionsPane);
     recordedPanes.value.length.should.equal(1);
-    await client.click('#btnPause');
-    recordedPanes = await client.elements('div[class*=Inspector__recorded-actions]');
+
+    // Pause the recording and check that the recorded actions pane is gone again
+    await InspectorPageObject.pauseRecording();
+    recordedPanes = await client.elements(InspectorPageObject.recordedActionsPane);
     recordedPanes.value.length.should.equal(0);
   });
 });

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -22,7 +22,7 @@ let client;
 
 describe('inspector window', function () {
 
-  let InspectorPageObject;
+  let inspector;
   
   before(async function () {
     // Start an Appium fake driver server
@@ -30,63 +30,63 @@ describe('inspector window', function () {
 
     // Navigate to session URL
     client = this.app.client;
-    InspectorPageObject = new InspectorPage(client);
-    InspectorPageObject.open('session');
+    inspector = new InspectorPage(client);
+    await inspector.open('session');
 
     // Set the desired capabilities
-    await client.waitForExist(InspectorPageObject.addDesiredCapabilityButton);
-    await InspectorPageObject.addDCaps(DEFAULT_CAPS);
+    await client.waitForExist(inspector.addDesiredCapabilityButton);
+    await inspector.addDCaps(DEFAULT_CAPS);
 
     // Set the fake driver server and port
-    await InspectorPageObject.setCustomServerHost('127.0.0.1');
-    await InspectorPageObject.setCustomServerPort(FAKE_DRIVER_PORT);
+    await inspector.setCustomServerHost('127.0.0.1');
+    await inspector.setCustomServerPort(FAKE_DRIVER_PORT);
 
     // Start the session
-    await InspectorPageObject.startSession();
+    await inspector.startSession();
   });
 
   after(async function () {
-    await InspectorPageObject.goHome();
+    await inspector.goHome();
   });
 
   beforeEach(async function () {
-    await client.waitForExist(InspectorPageObject.inspectorToolbar);
+    await client.waitForExist(inspector.inspectorToolbar);
   });
 
   it('shows content in "Selected Element" pane when clicking on an item in the Source inspector', async function () {
-    await client.getHTML(InspectorPageObject.selectedElementBody).should.eventually.contain('Select an element');
-    await client.waitForExist(InspectorPageObject.sourceTreeNode);
-    await client.click(InspectorPageObject.sourceTreeNode);
-    await client.waitForExist(InspectorPageObject.tapSelectedElementButton);
-    await client.getHTML(InspectorPageObject.selectedElementBody).should.eventually.contain('btnTapElement');
-    await client.click(InspectorPageObject.tapSelectedElementButton);
-    await InspectorPageObject.closeNotification();
+    await client.getHTML(inspector.selectedElementBody).should.eventually.contain('Select an element');
+    await client.waitForExist(inspector.sourceTreeNode);
+    await client.click(inspector.sourceTreeNode);
+    await client.waitForExist(inspector.tapSelectedElementButton);
+    await client.getHTML(inspector.selectedElementBody).should.eventually.contain('btnTapElement');
+    await client.click(inspector.tapSelectedElementButton);
+    await inspector.closeNotification();
   });
 
   it('shows a loading indicator in screenshot after clicking "Refresh" and then indicator goes away when refresh is complete', async function () {
-    await InspectorPageObject.reload();
-    const spinDots = await client.elements(InspectorPageObject.screenshotLoadingIndicator);
+    await inspector.reload();
+    const spinDots = await client.elements(inspector.screenshotLoadingIndicator);
     spinDots.value.length.should.equal(1);
     await retryInterval(15, 100, async () => {
-      const spinDots = await client.elements(InspectorPageObject.screenshotLoadingIndicator);
+      const spinDots = await client.elements(inspector.screenshotLoadingIndicator);
       spinDots.value.length.should.equal(0);
     });
   });
 
   it('shows a new pane when click "Start Recording" button and then the pane disappears when clicking "Pause"', async function () {
     // Check that there's no recorded actions pane
-    let recordedPanes = await client.elements(InspectorPageObject.recordedActionsPane);
+    let recordedPanes = await client.elements(inspector.recordedActionsPane);
     recordedPanes.value.length.should.equal(0);
 
     // Start a recording and check that there is a recorded actions pane
-    await InspectorPageObject.startRecording();
-    await client.waitForExist(InspectorPageObject.recordedActionsPane);
-    recordedPanes = await client.elements(InspectorPageObject.recordedActionsPane);
+    await inspector.startRecording();
+    await client.waitForExist(inspector.recordedActionsPane);
+    recordedPanes = await client.elements(inspector.recordedActionsPane);
     recordedPanes.value.length.should.equal(1);
 
     // Pause the recording and check that the recorded actions pane is gone again
-    await InspectorPageObject.pauseRecording();
-    recordedPanes = await client.elements(InspectorPageObject.recordedActionsPane);
+    await inspector.pauseRecording();
+    recordedPanes = await client.elements(inspector.recordedActionsPane);
     recordedPanes.value.length.should.equal(0);
   });
 });

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -4,6 +4,7 @@ import path from 'path';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
+
 const platform = os.platform();
 
 chai.should();
@@ -18,12 +19,12 @@ if (platform === 'linux') {
   appPath = path.join(__dirname, '..', '..', 'release', 'win-ia32-unpacked', 'Appium.exe');
 }
 
-before(function () {
+before(async function () {
   this.timeout(process.env.TRAVIS || process.env.APPVEYOR ? 10 * 60 * 1000 : 30 * 1000);
   this.app = new Application({
     path: appPath,
   });
-  return this.app.start();
+  await this.app.start();
 });
 
 after(function () {
@@ -33,8 +34,10 @@ after(function () {
 });
 
 describe('application launch', function () {
-  it('shows an initial window', async function () {
-    await this.app.client.getWindowCount().should.eventually.equal(1);
+  let initialWindowCount;
+
+  before(async function () {
+    initialWindowCount = await this.app.client.getWindowCount();
   });
 
   it('starts the server and opens a new session window', async function () {
@@ -47,6 +50,6 @@ describe('application launch', function () {
     source.value.indexOf('Welcome to Appium').should.be.above(0);
     client.element('*[class*="button-container"] button').click();
     await client.pause(500);
-    await client.getWindowCount().should.eventually.equal(2);
+    await client.getWindowCount().should.eventually.equal(initialWindowCount + 1);
   });
 });

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -36,27 +36,27 @@ after(function () {
 describe('application launch', function () {
   let initialWindowCount;
 
-  let MainPageObject;
+  let main;
   let client;
 
   before(async function () {
     client = this.app.client;
-    MainPageObject = new MainPage(client);
+    main = new MainPage(client);
     initialWindowCount = await this.app.client.getWindowCount();
   });
 
   it('starts the server and opens a new session window', async function () {
     // Start the server
-    await client.waitForExist(MainPageObject.startServerButton);
-    await MainPageObject.startServer();
+    await client.waitForExist(main.startServerButton);
+    await main.startServer();
 
     // Wait for the server monitor container to be present
-    await client.waitForExist(MainPageObject.serverMonitorContainer);
+    await client.waitForExist(main.serverMonitorContainer);
     const source = await client.source();
     source.value.indexOf('Welcome to Appium').should.be.above(0);
 
     // Start a new session and confirm that it opens a new window
-    await MainPageObject.startNewSession();
+    await main.startNewSession();
     await client.pause(500);
     await client.getWindowCount().should.eventually.equal(initialWindowCount + 1);
   });

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-
+import MainPage from './pages/main-page-object';
 
 const platform = os.platform();
 
@@ -36,19 +36,27 @@ after(function () {
 describe('application launch', function () {
   let initialWindowCount;
 
+  let MainPageObject;
+  let client;
+
   before(async function () {
+    client = this.app.client;
+    MainPageObject = new MainPage(client);
     initialWindowCount = await this.app.client.getWindowCount();
   });
 
   it('starts the server and opens a new session window', async function () {
-    var client = this.app.client;
-    await client.waitForExist('form button.ant-btn-primary');
-    var startServerBtn = client.element('form button.ant-btn-primary');
-    startServerBtn.click();
-    await client.waitForExist('div[class^="ServerMonitor"]');
+    // Start the server
+    await client.waitForExist(MainPageObject.startServerButton);
+    await MainPageObject.startServer();
+
+    // Wait for the server monitor container to be present
+    await client.waitForExist(MainPageObject.serverMonitorContainer);
     const source = await client.source();
     source.value.indexOf('Welcome to Appium').should.be.above(0);
-    client.element('*[class*="button-container"] button').click();
+
+    // Start a new session and confirm that it opens a new window
+    await MainPageObject.startNewSession();
     await client.pause(500);
     await client.getWindowCount().should.eventually.equal(initialWindowCount + 1);
   });

--- a/test/e2e/pages/base-page-object.js
+++ b/test/e2e/pages/base-page-object.js
@@ -1,4 +1,4 @@
-export default class InspectorPage {
+export default class BasePage {
 
   constructor (client) {
     this.client = client;

--- a/test/e2e/pages/base-page-object.js
+++ b/test/e2e/pages/base-page-object.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 export default class InspectorPage {
 
   constructor (client) {
@@ -10,7 +8,6 @@ export default class InspectorPage {
   async open (path) {
     const url = await this.client.url();
     this.originalUrl = url.value;
-    console.log('Navigating to ', `${this.originalUrl}/${path}`);
     await this.client.url(`${this.originalUrl}${path}`);
   }
 

--- a/test/e2e/pages/base-page-object.js
+++ b/test/e2e/pages/base-page-object.js
@@ -1,0 +1,23 @@
+import _ from 'lodash';
+
+export default class InspectorPage {
+
+  constructor (client) {
+    this.client = client;
+    this.originalUrl = client.url();
+  }
+
+  async open (path) {
+    const url = await this.client.url();
+    this.originalUrl = url.value;
+    console.log('Navigating to ', `${this.originalUrl}/${path}`);
+    await this.client.url(`${this.originalUrl}${path}`);
+  }
+
+  async goHome () {
+    if (this.originalUrl) {
+      await this.client.url(this.originalUrl);
+    }
+  }
+
+}

--- a/test/e2e/pages/inspector-page-object.js
+++ b/test/e2e/pages/inspector-page-object.js
@@ -4,60 +4,25 @@ import BasePage from './base-page-object';
 
 export default class InspectorPage extends BasePage {
 
+  static selectors = {
+    customServerHost: '#customServerHost',
+    customServerPort: '#customServerPort',
+    addDesiredCapabilityButton: '#btnAddDesiredCapability',
+    formSubmitButton: '#btnStartSession',
+    inspectorToolbar: 'div[class*=Inspector__inspector-toolbar]',
+    selectedElementBody: '#selectedElementContainer .ant-card-body',
+    tapSelectedElementButton:  '#selectedElementContainer #btnTapElement',
+    sourceTreeNode: '#sourceContainer .ant-tree-node-content-wrapper',
+    recordedActionsPane: 'div[class*=Inspector__recorded-actions]',
+    startRecordingButton: '#btnStartRecording',
+    pauseRecordingButton: '#btnPause',
+    reloadButton: '#btnReload',
+    screenshotLoadingIndicator: '#screenshotContainer .ant-spin-dot',
+  };
+
   constructor (client) {
     super(client);
-  }
-
-  get customServerHost () {
-    return '#customServerHost';
-  }
-
-  get customServerPort () {
-    return '#customServerPort';
-  }
-
-  get addDesiredCapabilityButton () {
-    return '#btnAddDesiredCapability';
-  }
-
-  get formSubmitButton () {
-    return '#btnStartSession';
-  }
-
-  get inspectorToolbar () {
-    return 'div[class*=Inspector__inspector-toolbar]';
-  }
-
-  get selectedElementBody () {
-    return '#selectedElementContainer .ant-card-body';
-  }
-
-  get tapSelectedElementButton () {
-    return '#selectedElementContainer #btnTapElement';
-  }
-
-  get sourceTreeNode () {
-    return '#sourceContainer .ant-tree-node-content-wrapper';
-  }
-
-  get recordedActionsPane () {
-    return 'div[class*=Inspector__recorded-actions]';
-  }
-
-  get startRecordingButton () {
-    return '#btnStartRecording';
-  }
-
-  get pauseRecordingButton () {
-    return '#btnPause';
-  }
-
-  get reloadButton () {
-    return '#btnReload';
-  }
-
-  get screenshotLoadingIndicator () {
-    return '#screenshotContainer .ant-spin-dot';
+    Object.assign(this, InspectorPage.selectors);
   }
 
   desiredCapabilityNameInput (rowIndex) {

--- a/test/e2e/pages/inspector-page-object.js
+++ b/test/e2e/pages/inspector-page-object.js
@@ -1,0 +1,113 @@
+import _ from 'lodash';
+import { retryInterval } from 'asyncbox';
+import BasePage from './base-page-object';
+
+export default class InspectorPage extends BasePage {
+
+  constructor (client) {
+    super(client);
+  }
+
+  get customServerHost () {
+    return '#customServerHost';
+  }
+
+  get customServerPort () {
+    return '#customServerPort';
+  }
+
+  get addDesiredCapabilityButton () {
+    return '#btnAddDesiredCapability';
+  }
+
+  get formSubmitButton () {
+    return '#btnStartSession';
+  }
+
+  get inspectorToolbar () {
+    return 'div[class*=Inspector__inspector-toolbar]';
+  }
+
+  get selectedElementBody () {
+    return '#selectedElementContainer .ant-card-body';
+  }
+
+  get tapSelectedElementButton () {
+    return '#selectedElementContainer #btnTapElement';
+  }
+
+  get sourceTreeNode () {
+    return '#sourceContainer .ant-tree-node-content-wrapper';
+  }
+
+  get recordedActionsPane () {
+    return 'div[class*=Inspector__recorded-actions]';
+  }
+
+  get startRecordingButton () {
+    return '#btnStartRecording';
+  }
+
+  get pauseRecordingButton () {
+    return '#btnPause';
+  }
+
+  get reloadButton () {
+    return '#btnReload';
+  }
+
+  get screenshotLoadingIndicator () {
+    return '#screenshotContainer .ant-spin-dot';
+  }
+
+  desiredCapabilityNameInput (rowIndex) {
+    return `#desiredCapabilityName_${rowIndex}`;
+  }
+
+  desiredCapabilityValueInput (rowIndex) {
+    return `#desiredCapabilityValue_${rowIndex}`;
+  }
+
+  async setCustomServerHost (host) {
+    await this.client.setValue(this.customServerHost, host);
+  }
+
+  async setCustomServerPort (host) {
+    await this.client.setValue(this.customServerPort, host);
+  }
+
+  async addDCaps (dcaps) {
+    const dcapsPairs = _.toPairs(dcaps);
+    for (let i = 0; i < dcapsPairs.length; i++) {
+      const [name, value] = dcapsPairs[i];
+      await this.client.setValue(this.desiredCapabilityNameInput(i), name);
+      await this.client.setValue(this.desiredCapabilityValueInput(i), value);
+      await this.client.click(this.addDesiredCapabilityButton);
+    }   
+  }
+
+  async startSession () {
+    await this.client.click(this.formSubmitButton);
+  }
+
+  async closeNotification () {
+    try {
+      await retryInterval(5, 500, () => {
+        this.client.click('.ant-notification-notice-close');
+      });
+    } catch (ign) { }
+  }
+
+  async startRecording () {
+    await this.client.click(this.startRecordingButton);
+  }
+
+  async pauseRecording () {
+    await this.client.click(this.pauseRecordingButton);
+  }
+
+  async reload () {
+    await this.client.click(this.reloadButton);
+  }
+
+}

--- a/test/e2e/pages/main-page-object.js
+++ b/test/e2e/pages/main-page-object.js
@@ -1,0 +1,28 @@
+import BasePage from './base-page-object';
+
+export default class MainPage extends BasePage {
+
+  constructor (client) {
+    super(client);
+  }
+
+  get startServerButton () {
+    return '#startServerBtn';
+  }
+
+  get startNewSessionButton () {
+    return '#startNewSessionBtn';
+  }
+
+  get serverMonitorContainer () {
+    return '#serverMonitorContainer';
+  }
+
+  async startServer () {
+    await this.client.click(this.startServerButton);
+  }
+
+  async startNewSession () {
+    await this.client.click(this.startNewSessionButton);
+  }
+}

--- a/test/e2e/pages/main-page-object.js
+++ b/test/e2e/pages/main-page-object.js
@@ -2,22 +2,17 @@ import BasePage from './base-page-object';
 
 export default class MainPage extends BasePage {
 
+  static selectors = {
+    startServerButton: '#startServerBtn',
+    startNewSessionButton: '#startNewSessionBtn',
+    serverMonitorContainer: '#serverMonitorContainer',
+  }
+
   constructor (client) {
     super(client);
+    Object.assign(this, MainPage.selectors);
   }
-
-  get startServerButton () {
-    return '#startServerBtn';
-  }
-
-  get startNewSessionButton () {
-    return '#startNewSessionBtn';
-  }
-
-  get serverMonitorContainer () {
-    return '#serverMonitorContainer';
-  }
-
+  
   async startServer () {
     await this.client.click(this.startServerButton);
   }


### PR DESCRIPTION
(review https://github.com/appium/appium-desktop/pull/234 first; this PR is ahead of it's tip)

* Starts a fakedriver session in inspector e2e test to be used to mock Appium sessions
* Added 'package-e2e-test' script that needs to be run before running e2e tests
* Added id attributes to elements to make them easier to select
* Tests record, refresh, select & tap element
* Updated main-e2e-test.js; sometimes the updater window shows up and that messes up the tests. Now it gets the initial window count now and then tests window count relative to initial count
* Updated CONTRIBUTING to explain how to run tests