### PR TITLE
Limit logs and write logs to file that can be opened by user

### DIFF
--- a/app/renderer/actions/ServerMonitor.js
+++ b/app/renderer/actions/ServerMonitor.js
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, shell } from 'electron';
 import { push } from 'react-router-redux';
 
 export const SERVER_STOP_REQ = 'SERVER_STOP_REQ';
@@ -85,5 +85,16 @@ export function startSession () {
   return (dispatch) => {
     dispatch({type: START_SESSION_REQUEST});
     ipcRenderer.send('create-new-session-window');
+  };
+}
+
+export function getRawLogs () {
+  return (dispatch, getState) => {
+    const logfilePath = getState().startServer.logfilePath;
+    if (logfilePath) {
+      shell.openExternal(`file://${logfilePath}`);
+    } else {
+      alert('An error has occurred: Logs not available');
+    }
   };
 }

--- a/app/renderer/actions/StartServer.js
+++ b/app/renderer/actions/StartServer.js
@@ -14,6 +14,7 @@ export const PRESET_SAVE_OK = 'PRESET_SAVE_OK';
 export const GET_PRESETS = 'GET_PRESETS';
 export const PRESET_DELETE_REQ = 'PRESET_DELETE_REQ';
 export const PRESET_DELETE_OK = 'PRESET_DELETE_OK';
+export const SET_LOGFILE_PATH = 'SET_LOGFILE_PATH';
 
 export const PRESETS = 'presets';
 
@@ -47,6 +48,7 @@ export function startServer (evt) {
     });
 
     dispatch(clearLogs());
+    ipcRenderer.once('path-to-logs', (event, logfilePath) => dispatch({type: SET_LOGFILE_PATH, logfilePath}));
     ipcRenderer.send('start-server', serverArgs);
   };
 }

--- a/app/renderer/components/ServerMonitor/ServerMonitor.css
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.css
@@ -57,11 +57,18 @@
   margin-right: 10px;
 }
 
-.stopButton {
+
+.serverButton {
   color: #a0a0a0 !important;
   background-image: none !important;
   background-color: #252525 !important;
   border-color: #a0a0a0 !important;
+}
+
+.getRawLogsButton {
+  position: absolute;
+  right: 0;
+  margin: 0 1em 0 0;
 }
 
 .term {

--- a/app/renderer/components/ServerMonitor/ServerMonitor.js
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.js
@@ -31,15 +31,15 @@ class StopButton extends Component {
 
   render () {
     const {serverStatus, stopServer, closeMonitor} = this.props;
-    let btn = <Button icon="pause-circle-o" className={styles.stopButton}
+    let btn = <Button icon="pause-circle-o" className={styles.serverButton}
                onClick={stopServer}>Stop Server</Button>;
     if (serverStatus === STATUS_STOPPED) {
-      btn = <Button className={styles.stopButton}
+      btn = <Button className={styles.serverButton}
              icon="close-circle-o"
              onClick={closeMonitor}>Close Logs</Button>;
     } else if (serverStatus === STATUS_STOPPING) {
       btn = <Button icon="pause-circle-o"
-             className={styles.stopButton} type="disabled">Stopping...</Button>;
+             className={styles.serverButton} type="disabled">Stopping...</Button>;
     }
     return btn;
   }
@@ -54,12 +54,20 @@ class StartSessionButton extends Component {
   render () {
     const {serverStatus, startSession} = this.props;
     if (serverStatus !== STATUS_STOPPED && serverStatus !== STATUS_STOPPING) {
-      return <Button className={styles.stopButton} id='startNewSessionBtn'
+      return <Button className={styles.serverButton} id='startNewSessionBtn'
               icon="play-circle-o"
              onClick={startSession}>Start New Session</Button>;
     } else {
       return null;
     }
+  }
+}
+
+class GetRawLogsButton extends Component {
+  render () {
+    return <Button className={`${styles.getRawLogsButton} ${styles.serverButton}`}
+             icon="file-text"
+             onClick={() => this.props.getRawLogs()}>Get raw logs</Button>;
   }
 }
 
@@ -149,6 +157,7 @@ export default class ServerMonitor extends Component {
           </div>
         </div>
         <div className={termClass} ref={(c) => this._term = c}>
+          <GetRawLogsButton {...this.props} />
           {logLineSection}
           {lastSection}
         </div>

--- a/app/renderer/components/ServerMonitor/ServerMonitor.js
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.js
@@ -6,6 +6,7 @@ import styles from './ServerMonitor.css';
 import AnsiConverter from 'ansi-to-html';
 
 const convert = new AnsiConverter({fg: '#bbb', bg: '#222'});
+const MAX_LOGS_RENDERED = 1000;
 
 function leveler (level) {
   switch (level) {
@@ -63,6 +64,7 @@ class StartSessionButton extends Component {
 }
 
 export default class ServerMonitor extends Component {
+
   static propTypes = {
     stopServer: PropTypes.func.isRequired,
     closeMonitor: PropTypes.func.isRequired,
@@ -106,7 +108,7 @@ export default class ServerMonitor extends Component {
         throw new Error(`Bad status: ${serverStatus}`);
     }
 
-    let logLineSection = logLines.map((line, i) => {
+    let logLineSection = logLines.slice(logLines.length - MAX_LOGS_RENDERED).map((line, i) => {
       let icn = leveler(line.level);
       return (
         <div key={i}>

--- a/app/renderer/reducers/ServerMonitor.js
+++ b/app/renderer/reducers/ServerMonitor.js
@@ -18,6 +18,7 @@ const initialState = {
 };
 
 export default function serverMonitor (state = initialState, action) {
+  let logLines;
   switch (action.type) {
     case SERVER_STOP_REQ:
       return {...state, serverStatus: STATUS_STOPPING};
@@ -40,8 +41,7 @@ export default function serverMonitor (state = initialState, action) {
         sessionId: action.sessionUUID,
       };
     case LOGS_RECEIVED:
-      // TODO: We should dump logs to a txt file that can be exported
-      var logLines = state.logLines.concat(action.logs.map((l) => {
+      logLines = state.logLines.concat(action.logs.map((l) => {
         // attach a timestamp to each log line here when it comes in
         l.timestamp = moment().format('YYYY-MM-DD hh:mm:ss');
         return l;

--- a/app/renderer/reducers/ServerMonitor.js
+++ b/app/renderer/reducers/ServerMonitor.js
@@ -7,6 +7,9 @@ export const STATUS_RUNNING = "running";
 export const STATUS_STOPPED = "stopped";
 export const STATUS_STOPPING = "stopping";
 
+// Maximum amount of logs to keep in memory
+const MAX_LOG_LINES = 10000;
+
 const initialState = {
   logLines: [],
   serverStatus: STATUS_STOPPED,
@@ -37,13 +40,21 @@ export default function serverMonitor (state = initialState, action) {
         sessionId: action.sessionUUID,
       };
     case LOGS_RECEIVED:
+      // TODO: We should dump logs to a txt file that can be exported
+      var logLines = state.logLines.concat(action.logs.map((l) => {
+        // attach a timestamp to each log line here when it comes in
+        l.timestamp = moment().format('YYYY-MM-DD hh:mm:ss');
+        return l;
+      }));
+
+      // Don't log more than MAX_LOG_LINES
+      if (logLines.length > MAX_LOG_LINES) {
+        logLines = logLines.slice(logLines.length - MAX_LOG_LINES);
+      }
+
       return {
         ...state,
-        logLines: state.logLines.concat(action.logs.map((l) => {
-          // attach a timestamp to each log line here when it comes in
-          l.timestamp = moment().format('YYYY-MM-DD hh:mm:ss');
-          return l;
-        })),
+        logLines,
         serverStatus: STATUS_RUNNING
       };
     case LOGS_CLEARED:

--- a/app/renderer/reducers/StartServer.js
+++ b/app/renderer/reducers/StartServer.js
@@ -1,6 +1,6 @@
 import { SERVER_START_REQ, SERVER_START_OK, SERVER_START_ERR, GET_PRESETS,
          UPDATE_ARGS, SWITCH_TAB, PRESET_SAVE_REQ, PRESET_SAVE_OK,
-         PRESET_DELETE_REQ, PRESET_DELETE_OK
+         PRESET_DELETE_REQ, PRESET_DELETE_OK, SET_LOGFILE_PATH,
        } from '../actions/StartServer';
 
 import { ipcRenderer } from 'electron';
@@ -50,6 +50,8 @@ export default function startServer (state = initialState, action) {
       return {...state, presetDeleting: true};
     case PRESET_DELETE_OK:
       return {...state, presetDeleting: false, presets: action.presets};
+    case SET_LOGFILE_PATH:
+      return {...state, logfilePath: action.logfilePath};
     default:
       return state;
   }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "ansi-to-html": "0.5",
     "antd": "2.10.1",
     "appium": "1.6.5",
+    "appium-support": "^2.8.2",
     "bluebird": "3.x",
     "css-modules-require-hook": "4.x",
     "electron-debug": "1.x",


### PR DESCRIPTION
* Limit logs to 1000
  * When logs get above 1000, the app slows down/crashes. Limit the number of rendered logs to 1000
* Log writing
  * Main thread writes all logs to file
  * Main thread sends the filepath of the logs to the browser window
  * Added 'GetRawLogsButton' to server monitor component
  * When button is clicked, opens the file externally
  * Delete logfile when browser closed
  * If logfile not present, show an alert to indicate that logs can't be accessed