### PR TITLE
Reload source when selected element is stale

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -138,14 +138,14 @@ export function selectElement (path) {
     if (!elementId) {
       // If the element is stale, unselect and reload the source
       dispatch({type: UNSELECT_ELEMENT});
-      await applyClientMethod({methodName: 'source'})(dispatch);
-    } else {
-      // Set the elementId, variableName and variableType for the selected element 
-      // (check first that the selectedElementPath didn't change, to avoid race conditions)
-      if (getState().inspector.selectedElementPath === path) {
-        dispatch({type: SET_SELECTED_ELEMENT_ID, elementId, variableName, variableType});
-      }
-    }    
+      return await applyClientMethod({methodName: 'source'})(dispatch);
+    } 
+
+    // Set the elementId, variableName and variableType for the selected element 
+    // (check first that the selectedElementPath didn't change, to avoid race conditions)
+    if (getState().inspector.selectedElementPath === path) {
+      dispatch({type: SET_SELECTED_ELEMENT_ID, elementId, variableName, variableType});
+    }
   };
 }
 

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -130,17 +130,22 @@ export function selectElement (path) {
     const [optimalStrategy, optimalSelector] = strategyMap.length > 0 ? strategyMap[strategyMap.length - 1] : ['xpath', selectedElementXPath];
 
     // Get the information about the element
-    const {elementId, variableName, variableType} = await callClientMethod({
+    let {elementId, variableName, variableType} = await callClientMethod({
       strategy: optimalStrategy,
       selector: optimalSelector,
     });
 
-    // Set the elementId, variableName and variableType for the selected element 
-    // (check first that the selectedElementPath didn't change, to avoid race conditions)
-    if (getState().inspector.selectedElementPath === path) {
-      dispatch({type: SET_SELECTED_ELEMENT_ID, elementId, variableName, variableType});
-    }
-    
+    if (!elementId) {
+      // If the element is stale, unselect and reload the source
+      dispatch({type: UNSELECT_ELEMENT});
+      await applyClientMethod({methodName: 'source'})(dispatch);
+    } else {
+      // Set the elementId, variableName and variableType for the selected element 
+      // (check first that the selectedElementPath didn't change, to avoid race conditions)
+      if (getState().inspector.selectedElementPath === path) {
+        dispatch({type: SET_SELECTED_ELEMENT_ID, elementId, variableName, variableType});
+      }
+    }    
   };
 }
 


### PR DESCRIPTION
* If an element is stale, when you select an element it will try to find it and won't find it in the source
* This PR, if it encounters a stale element, automatically reloads the source 

(addresses https://github.com/appium/appium-desktop/issues/319)

p.s.: @mykola-mokhnach @imurchie I know A.D. is out of your domain, but with JLipps away I need somebody to have a look at the PR's