### PR TITLE
Use multiple selector strategies if first one doesn't work

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -125,7 +125,7 @@ const findElement = _.debounce(async function (strategyMap, dispatch, getState, 
   // If we couldn't find the element, show a notification
   notification.error({
     message: 'Error',
-    description: 'Could not find element. Try refreshing page',
+    description: 'Could not find the element. Try refreshing.',
     duration: 0,
   });
 }, 1000);


### PR DESCRIPTION
* Don't refresh page if we couldn't find element, instead just try the next locator strategy
* If nothing is found, show a notification recommending refreshing instead of just refreshing
* The previous refreshing feature was a mistake, because if the element can never be found it will ALWAYS refresh