### PR TITLE
Make test for no PrivateHeaders problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "css-loader": "^0.28.8",
     "del": "2.x",
     "devtron": "1.x",
+    "dir-compare": "^1.4.0",
     "electron": "1.7.11",
     "electron-builder": "^19.53.4",
     "electron-devtools-installer": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "e2e": "cross-env FORCE_NO_WRONG_FOLDER=true mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/e2e",
     "integration": "mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/integration",
     "unit-test": "mocha --compilers js:babel-core/register ./test/unit",
+    "test-all": "npm run unit-test && npm run integration && npm run e2e",
     "lint": "eslint app test *.js",
     "hot-server": "node -r ./node_modules/babel-register server.js --color",
     "build-main": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors --color",
     "build-renderer": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors --color",
     "build": "npm run build-main && npm run build-renderer",
+    "clean": "rimraf node_modules && npm install",
     "start": "cross-env NODE_ENV=production electron ./",
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r ./node_modules/babel-register -r ./node_modules/babel-polyfill ./app/main/main.development --color",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
@@ -41,8 +43,7 @@
     "package-win": "npm run build && build --win --x64",
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
-    "package-e2e-test": "npm run build && build --dir",
-    "package-ci": "npm run integration && npm run build && npm run package-e2e-test && npm run e2e && build --publish onTagOrDraft",
+    "package-ci": "npm run clean && npm run build && build --dir && npm run test-all && build --publish onTagOrDraft",
     "postversion": "git pull --tags && git push && git push --tags"
   },
   "build": {

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import dirCompare from 'dir-compare';
 import MainPage from './pages/main-page-object';
 
 const platform = os.platform();
@@ -62,14 +63,19 @@ describe('application launch', function () {
     await client.getWindowCount().should.eventually.equal(initialWindowCount + 1);
   });
 
-  it('check that WebDriverAgent private headers folder (regression test for https://github.com/appium/appium-desktop/issues/417)', async function () {
+  it('check that WebDriverAgent folder is the same in /releases as it is in /node_modules (regression test for https://github.com/appium/appium-desktop/issues/417)', async function () {
     // NOTE: This isn't really an "e2e" test, but the test has to be written here because the /release 
     // folder needs to be built in order to run the test
-    if (platform === 'darwin') {
-      this.skip();
+    if (platform !== 'darwin') {
+      return this.skip();
     }
 
-    const resourcesPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'Resources');
-    await fs.exists(path.resolve(resourcesPath, 'app', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent', 'PrivateHeaders')).should.eventually.be.true;
+    const resourcesWDAPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'Resources', 
+      'app', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent');
+
+    const localWDAPath = path.join(__dirname, '..', '..', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent');
+
+    const res = await dirCompare.compare(resourcesWDAPath, localWDAPath);
+    res.distinct.should.equal(0);
   });
 });

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -1,4 +1,5 @@
 import { Application } from  'spectron';
+import { fs } from 'appium-support';
 import os from 'os';
 import path from 'path';
 import chai from 'chai';
@@ -59,5 +60,14 @@ describe('application launch', function () {
     await main.startNewSession();
     await client.pause(500);
     await client.getWindowCount().should.eventually.equal(initialWindowCount + 1);
+  });
+
+  it('check that WebDriverAgent private headers folder (regression test for https://github.com/appium/appium-desktop/issues/417)', async function () {
+    // NOTE: This isn't really an "e2e" test, but the test has to be written here because the /release 
+    // folder needs to be built in order to run the test
+    if (platform === 'darwin') {
+      const resourcesPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'Resources');
+      await fs.exists(path.resolve(resourcesPath, 'app', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent', 'PrivateHeaders')).should.eventually.be.true;
+    }
   });
 });

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -66,8 +66,10 @@ describe('application launch', function () {
     // NOTE: This isn't really an "e2e" test, but the test has to be written here because the /release 
     // folder needs to be built in order to run the test
     if (platform === 'darwin') {
-      const resourcesPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'Resources');
-      await fs.exists(path.resolve(resourcesPath, 'app', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent', 'PrivateHeaders')).should.eventually.be.true;
+      this.skip();
     }
+
+    const resourcesPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'Resources');
+    await fs.exists(path.resolve(resourcesPath, 'app', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent', 'PrivateHeaders')).should.eventually.be.true;
   });
 });


### PR DESCRIPTION
* Looks like when using electron-builder with Node 9 and building assets to the `release/` folder, PrivateHeaders does not get transferred
* Added a test that verifies the `PrivateHeaders` folder is there so that this does not occur in the future
* Also, edited the scripts in package.json so that all of the tests are run, node modules are deleted and installed and removed a redundancy