### PR TITLE
Check NPM and Node versions before packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
   "homepage": "https://github.com/chentsulin/electron-react-boilerplate#readme",
   "main": "main.js",
   "scripts": {
-    "test": "npm run unit-test",
-    "e2e": "cross-env FORCE_NO_WRONG_FOLDER=true mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/e2e",
-    "integration": "mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/integration",
-    "unit-test": "mocha --compilers js:babel-core/register ./test/unit",
-    "test-all": "npm run unit-test && npm run integration && npm run e2e",
+    "test": "npm run test-unit && npm run test-integration",
+    "test-e2e": "cross-env FORCE_NO_WRONG_FOLDER=true mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/e2e",
+    "test-integration": "mocha --timeout 600000 --compilers js:babel-core/register --require ./node_modules/babel-polyfill/dist/polyfill.min.js ./test/integration",
+    "test-unit": "mocha --compilers js:babel-core/register ./test/unit",
     "lint": "eslint app test *.js",
     "hot-server": "node -r ./node_modules/babel-register server.js --color",
     "build-main": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors --color",
@@ -36,14 +35,14 @@
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r ./node_modules/babel-register -r ./node_modules/babel-polyfill ./app/main/main.development --color",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "dev": "concurrently --kill-others \"npm run hot-server\" \"npm run start-hot\" --color",
-    "dev:wrong-folder": "cross-env WRONG_FOLDER=true npm run dev",
+    "dev-wrong-folder": "cross-env WRONG_FOLDER=true npm run dev",
     "dev-mock-update": "cross-env MOCK_AUTO_UPDATER=true npm run dev",
     "dev-mock-failed-update": "cross-env MOCK_FAILED_UPDATE=true npm run dev-mock-update",
     "package": "npm run build && build --publish never",
     "package-win": "npm run build && build --win --x64",
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
-    "package-ci": "npm run build && build --dir && npm run test-all && build --publish onTagOrDraft",
+    "package-ci": "check-engines && npm run test && npm run build && build --dir && npm run test-e2e && build --publish onTagOrDraft",
     "postversion": "git pull --tags && git push && git push --tags"
   },
   "build": {
@@ -115,7 +114,7 @@
     "highlight.js": "9.x",
     "lodash": "4.x",
     "moment": "^2.20.1",
-    "postcss": "^5.2.18",
+    "postcss": "^6.0.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-redux": "4.x",
@@ -153,6 +152,7 @@
     "babel-register": "^6.26.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "check-engines": "^1.5.0",
     "concurrently": "^3.5.1",
     "cross-env": "3.x",
     "css-loader": "^0.28.8",
@@ -197,5 +197,9 @@
   "devEngines": {
     "node": ">=6.x",
     "npm": ">=3.x"
+  },
+  "engines": {
+    "node": "=6.x",
+    "npm": "=3.x"
   }
 }

--- a/test/e2e/main-e2e.test.js
+++ b/test/e2e/main-e2e.test.js
@@ -71,9 +71,9 @@ describe('application launch', function () {
     }
 
     const resourcesWDAPath = path.join(__dirname, '..', '..', 'release', 'mac', 'Appium.app', 'Contents', 'Resources', 
-      'app', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent');
+      'app', 'node_modules', 'appium', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent');
 
-    const localWDAPath = path.join(__dirname, '..', '..', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent');
+    const localWDAPath = path.join(__dirname, '..', '..', 'node_modules', 'appium', 'node_modules', 'appium-xcuitest-driver', 'WebDriverAgent');
 
     const res = await dirCompare.compare(resourcesWDAPath, localWDAPath);
     res.distinct.should.equal(0);


### PR DESCRIPTION
* Add check-engine to package-ci script
* Require NPM 3 and Node 6 when running `package-ci` script
  * This is to prevent problems we had when using newer versions of NPM/Node
  * This package isn't published to NPM and these constraints don't apply to the version of Node used in the Electron main thread, thus having strict constraints isn't a big problem
  * This won't effect contributors, contributors can still use engines that are defined in `devEngines`. It's only the `package-ci` script that has the strict requirements
* Fix e2e test because it uses nested `node_modules`
* Standardize names of NPM scripts
* Fixed `npm run clean` to install `rimraf` before calling `rimraf` on `node_modules`
* Upgraded postcss to resolve peer dependency issue