### PR TITLE
Fix windows autoupdater

### DIFF
--- a/app/main/menus.js
+++ b/app/main/menus.js
@@ -1,4 +1,4 @@
-import { app, shell } from 'electron';
+import { app, shell, dialog } from 'electron';
 import { createNewSessionWindow } from './appium';
 import { checkNewUpdates } from './auto-updater';
 
@@ -163,7 +163,10 @@ function otherMenuFile (mainWindow) {
   }, {
     label: '&About Appium',
     click () {
-      checkNewUpdates(true);
+      dialog.showMessageBox({
+        title: 'Appium Desktop',
+        message: `Version ${app.getVersion()}`,
+      });
     }
   }, {
     type: 'separator'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "description": "Graphical interface for the Appium server, and an app inspector",
   "repository": {
     "type": "git",
@@ -75,9 +75,8 @@
       "package.json"
     ],
     "win": {
-      "target": [
-        "nsis"
-      ]
+      "target": "squirrel",
+      "icon": "build/icon.ico"
     },
     "linux": {
       "target": [
@@ -159,6 +158,7 @@
     "dir-compare": "^1.4.0",
     "electron": "1.7.11",
     "electron-builder": "^19.53.4",
+    "electron-builder-squirrel-windows": "^20.3.1",
     "electron-devtools-installer": "^2.2.3",
     "eslint": "3.x",
     "eslint-config-appium": "1.x",


### PR DESCRIPTION
* Change the target from NSIS to Squirrel to allow auto updating 
  * Tested it by:
    * Building a temporary 1.4.1 build and publishing it temporarily
    * Packaging 1.4.0 app
    * Installing the 1.4.0 Application file
    * Installing the update
* Fixed the 'About Appium' options