### PR TITLE
Fix autoupdater on dev

### DIFF
--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -43,7 +43,7 @@ if (!isDev) {
       }, (response) => {
         if (response === 0) {
           // If they say yes, get the updates now
-          autoUpdater.checkForUpdates();
+          getUpdates();
         }
       });
     } else {
@@ -88,9 +88,9 @@ if (!isDev) {
         `Must restart to apply the updates ` +
         `(note: it may take several minutes for Appium Desktop to install and restart)`,
     }, (response) => {
-      // If they say yes, get the updates now
+      // If they say yes, restart now
       if (response === 0) {
-        getUpdates();
+        autoUpdater.quitAndInstall();
       }
     });
   });

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -7,9 +7,12 @@
 import { app, autoUpdater, dialog } from 'electron';
 import moment from 'moment';
 import B from 'bluebird';
-import _ from 'lodash';
-import { getUpdate } from './update-checker';
+import { checkUpdate } from './update-checker';
 import { getFeedUrl } from './config';
+import _ from 'lodash';
+
+// Alias 'checkForUpdates' as 'getUpdates' to avoid confusion ('checkForUpdates' downloads updates automatically)
+const {checkForUpdates:getUpdates} = autoUpdater;
 
 const isDev = process.env.NODE_ENV === 'development';
   
@@ -26,9 +29,9 @@ if (!isDev) {
     // autoupdate.checkForUpdates always downloads updates immediately 
     // This method (getUpdate) let's us take a peek to see if there is an update 
     // available before calling .checkForUpdates
-    const update = await getUpdate(app.getVersion());
+    const update = await checkUpdate(app.getVersion());
     if (update) {
-      let {name, notes, pubDate:pubDate} = update;
+      let {name, notes, pub_date:pubDate} = update;
       pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
 
       // Ask user if they wish to install now or later
@@ -85,8 +88,9 @@ if (!isDev) {
         `Must restart to apply the updates ` +
         `(note: it may take several minutes for Appium Desktop to install and restart)`,
     }, (response) => {
+      // If they say yes, get the updates now
       if (response === 0) {
-        autoUpdater.quitAndInstall();
+        getUpdates();
       }
     });
   });

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -7,88 +7,99 @@
 import { app, autoUpdater, dialog } from 'electron';
 import moment from 'moment';
 import B from 'bluebird';
+import _ from 'lodash';
 import { getUpdate } from './update-checker';
 import { getFeedUrl } from './config';
+
+const isDev = process.env.NODE_ENV === 'development';
   
-autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
+let checkNewUpdates = _.noop;
 
-/** 
- * Check for new updates
- */
-export async function checkNewUpdates (fromMenu) {
-  // autoupdate.checkForUpdates always downloads updates immediately 
-  // This method (getUpdate) let's us take a peek to see if there is an update 
-  // available before calling .checkForUpdates
-  const update = await getUpdate(app.getVersion());
-  if (update) {
-    let {name, notes, pubDate:pubDate} = update;
-    pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
+if (!isDev) {
 
-    // Ask user if they wish to install now or later
+  autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
+
+  /** 
+   * Check for new updates
+   */
+  checkNewUpdates = async function (fromMenu) {
+    // autoupdate.checkForUpdates always downloads updates immediately 
+    // This method (getUpdate) let's us take a peek to see if there is an update 
+    // available before calling .checkForUpdates
+    const update = await getUpdate(app.getVersion());
+    if (update) {
+      let {name, notes, pubDate:pubDate} = update;
+      pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
+
+      // Ask user if they wish to install now or later
+      dialog.showMessageBox({
+        type: 'info',
+        buttons: ['Install Now', 'Install Later'],
+        message: `Appium Desktop ${name} is available`,
+        detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
+      }, (response) => {
+        if (response === 0) {
+          // If they say yes, get the updates now
+          autoUpdater.checkForUpdates();
+        }
+      });
+    } else {
+      if (fromMenu) {
+        autoUpdater.emit('update-not-available');
+      } else {
+        // If no updates found check for updates every hour
+        await B.delay(60 * 60 * 1000);
+        checkNewUpdates();
+      }
+    }
+  };
+
+  // Inform user when the download is starting and that they'll be notified again when it is complete
+  autoUpdater.on('update-available', () => {
     dialog.showMessageBox({
       type: 'info',
-      buttons: ['Install Now', 'Install Later'],
-      message: `Appium Desktop ${name} is available`,
-      detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
+      buttons: ['Ok'],
+      message: 'Update Download Started',
+      detail: 'Update is being downloaded now. You will be notified again when it is complete',
+    });
+  });
+
+  // Handle the unusual case where we checked the updates endpoint, found an update
+  // but then after calling 'checkForUpdates', nothing was there
+  autoUpdater.on('update-not-available', () => {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Ok'],
+      message: 'No update available',
+      detail: 'Appium Desktop is up-to-date',
+    });
+  });
+
+  // When it's done, ask if user want to restart now or later
+  autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Restart Now', 'Later'],
+      message: 'Update Downloaded',
+      detail: `Appium Desktop ${releaseName} has been downloaded. ` +
+        `Must restart to apply the updates ` +
+        `(note: it may take several minutes for Appium Desktop to install and restart)`,
     }, (response) => {
       if (response === 0) {
-        // If they say yes, get the updates now
-        autoUpdater.checkForUpdates();
+        autoUpdater.quitAndInstall();
       }
     });
-  } else {
-    if (fromMenu) {
-      autoUpdater.emit('update-not-available');
-    } else {
-      // If no updates found check for updates every hour
-      await B.delay(60 * 60 * 1000);
-      checkNewUpdates();
-    }
-  }
+  });
+
+  // Handle error case
+  autoUpdater.on('error', (message) => {
+    dialog.showMessageBox({
+      type: 'error',
+      message: 'Could not download update',
+      detail: `Failed to download update. Reason: ${message}`,
+    });
+  });
+
 }
 
-// Inform user when the download is starting and that they'll be notified again when it is complete
-autoUpdater.on('update-available', () => {
-  dialog.showMessageBox({
-    type: 'info',
-    buttons: ['Ok'],
-    message: 'Update Download Started',
-    detail: 'Update is being downloaded now. You will be notified again when it is complete',
-  });
-});
-
-// Handle the unusual case where we checked the updates endpoint, found an update
-// but then after calling 'checkForUpdates', nothing was there
-autoUpdater.on('update-not-available', () => {
-  dialog.showMessageBox({
-    type: 'info',
-    buttons: ['Ok'],
-    message: 'No update available',
-    detail: 'Appium Desktop is up-to-date',
-  });
-});
-
-// When it's done, ask if user want to restart now or later
-autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
-  dialog.showMessageBox({
-    type: 'info',
-    buttons: ['Restart Now', 'Later'],
-    message: 'Update Downloaded',
-    detail: `Appium Desktop ${releaseName} has been downloaded. ` +
-      `Must restart to apply the updates ` +
-      `(note: it may take several minutes for Appium Desktop to install and restart)`,
-  }, (response) => {
-    if (response === 0) {
-      autoUpdater.quitAndInstall();
-    }
-  });
-});
-
-// Handle error case
-autoUpdater.on('error', (message) => {
-  dialog.showMessageBox({
-    type: 'error',
-    message: 'Could not download update',
-    detail: `Failed to download update. Reason: ${message}`,
-  });
-});
+export { checkNewUpdates };

--- a/app/main/auto-updater/update-checker.js
+++ b/app/main/auto-updater/update-checker.js
@@ -1,7 +1,7 @@
 import request from 'request-promise';
 import { getFeedUrl } from './config';
 
-export async function getUpdate (currentVersion) {
+export async function checkUpdate (currentVersion) {
   try {
     const res = await request.get(getFeedUrl(currentVersion));
     if (res) {


### PR DESCRIPTION
* When it's dev, make `checkNewUpdates` a no-op and skip over the autoupdate methods
* This prevents it from attempting to do an update when it's dev

(NOTE: The patch looks more complicated then it is, it just wraps the code in an if statement)