### PR TITLE
Allow unauthorized SSL and Proxy

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -215,55 +215,49 @@ export function createNewSessionWindow (win) {
 function connectCreateNewSession () {
   ipcMain.on('appium-create-new-session', async (event, args) => {
     const {desiredCapabilities, host, port, path, username, accessKey, https,
-      attachSessId, rejectUnauthorized} = args;
+      attachSessId, rejectUnauthorized, proxy} = args;
 
-    // If there is an already active session, kill it. Limit one session per window.
-    if (sessionDrivers[event.sender.id]) {
-      await killSession(event.sender);
-    }
+    try {
+      // If there is an already active session, kill it. Limit one session per window.
+      if (sessionDrivers[event.sender.id]) {
+        await killSession(event.sender);
+      }
 
-    // Create the driver and cache it by the sender ID
-    wd.configureHttp({rejectUnauthorized});
-    let driver = sessionDrivers[event.sender.id] = wd.promiseChainRemote({
-      hostname: host,
-      port,
-      path,
-      username,
-      accessKey,
-      https,
-    });
-    appiumHandlers[event.sender.id] = new AppiumMethodHandler(driver);
+      // Create the driver and cache it by the sender ID
+      let driver = sessionDrivers[event.sender.id] = wd.promiseChainRemote({
+        hostname: host,
+        port,
+        path,
+        username,
+        accessKey,
+        https,
+      });
+      driver.configureHttp({rejectUnauthorized, proxy});
+      appiumHandlers[event.sender.id] = new AppiumMethodHandler(driver);
 
-    // If we're just attaching to an existing session, do that and
-    // short-circuit the rest of the logic
-    if (attachSessId) {
-      driver._isAttachedSession = true;
-      try {
+      // If we're just attaching to an existing session, do that and
+      // short-circuit the rest of the logic
+      if (attachSessId) {
+        driver._isAttachedSession = true;
         await driver.attach(attachSessId);
         // get the session capabilities to prove things are working
         await driver.sessionCapabilities();
         event.sender.send('appium-new-session-ready');
-      } catch (e) {
-        // If the session failed to attach, delete it from the cache
-        await killSession(event.sender);
-        event.sender.send('appium-new-session-failed', e);
+        return;
       }
-      return;
-    }
 
-    // If a newCommandTimeout wasn't provided, set it to 0 so that sessions don't close on users
-    if (!desiredCapabilities.newCommandTimeout) {
-      desiredCapabilities.newCommandTimeout = 0;
-    }
+      // If a newCommandTimeout wasn't provided, set it to 0 so that sessions don't close on users
+      if (!desiredCapabilities.newCommandTimeout) {
+        desiredCapabilities.newCommandTimeout = 0;
+      }
 
-    // If someone didn't specify connectHardwareKeyboard, set it to true by
-    // default
-    if (typeof desiredCapabilities.connectHardwareKeyboard === "undefined") {
-      desiredCapabilities.connectHardwareKeyboard = true;
-    }
+      // If someone didn't specify connectHardwareKeyboard, set it to true by
+      // default
+      if (typeof desiredCapabilities.connectHardwareKeyboard === "undefined") {
+        desiredCapabilities.connectHardwareKeyboard = true;
+      }
 
-    // Try initializing it. If it fails, kill it and send error message to sender
-    try {
+      // Try initializing it. If it fails, kill it and send error message to sender
       let p = driver.init(desiredCapabilities);
       event.sender.send('appium-new-session-successful');
       await p;

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -215,7 +215,7 @@ export function createNewSessionWindow (win) {
 function connectCreateNewSession () {
   ipcMain.on('appium-create-new-session', async (event, args) => {
     const {desiredCapabilities, host, port, path, username, accessKey, https,
-      attachSessId} = args;
+      attachSessId, rejectUnauthorized} = args;
 
     // If there is an already active session, kill it. Limit one session per window.
     if (sessionDrivers[event.sender.id]) {
@@ -223,6 +223,7 @@ function connectCreateNewSession () {
     }
 
     // Create the driver and cache it by the sender ID
+    wd.configureHttp({rejectUnauthorized});
     let driver = sessionDrivers[event.sender.id] = wd.promiseChainRemote({
       hostname: host,
       port,

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -13,9 +13,10 @@ import _ from 'lodash';
 
 const isDev = process.env.NODE_ENV === 'development';
   
-let checkNewUpdates = _.noop;
 
-if (!isDev) {
+let checkNewUpdates;
+
+if (process.env.NODE_ENV !== 'development') {
 
   autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
 
@@ -26,9 +27,9 @@ if (!isDev) {
     // autoupdate.checkForUpdates always downloads updates immediately 
     // This method (getUpdate) let's us take a peek to see if there is an update 
     // available before calling .checkForUpdates
-    const update = await checkUpdate(app.getVersion());
+    const update = await getUpdate(app.getVersion());
     if (update) {
-      let {name, notes, pub_date:pubDate} = update;
+      let {name, notes, pubDate:pubDate} = update;
       pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
 
       // Ask user if they wish to install now or later
@@ -52,7 +53,7 @@ if (!isDev) {
         checkNewUpdates();
       }
     }
-  };
+  }
 
   // Inform user when the download is starting and that they'll be notified again when it is complete
   autoUpdater.on('update-available', () => {
@@ -85,7 +86,6 @@ if (!isDev) {
         `Must restart to apply the updates ` +
         `(note: it may take several minutes for Appium Desktop to install and restart)`,
     }, (response) => {
-      // If they say yes, restart now
       if (response === 0) {
         autoUpdater.quitAndInstall();
       }
@@ -100,7 +100,6 @@ if (!isDev) {
       detail: `Failed to download update. Reason: ${message}`,
     });
   });
-
 }
 
 export { checkNewUpdates };

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -13,93 +13,85 @@ import _ from 'lodash';
 
 const isDev = process.env.NODE_ENV === 'development';
   
+autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
 
-let checkNewUpdates;
+/** 
+ * Check for new updates
+ */
+export async function checkNewUpdates (fromMenu) {
+  // autoupdate.checkForUpdates always downloads updates immediately 
+  // This method (getUpdate) let's us take a peek to see if there is an update 
+  // available before calling .checkForUpdates
+  const update = await getUpdate(app.getVersion());
+  if (update) {
+    let {name, notes, pubDate:pubDate} = update;
+    pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
 
-if (process.env.NODE_ENV !== 'development') {
-
-  autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
-
-  /** 
-   * Check for new updates
-   */
-  checkNewUpdates = async function (fromMenu) {
-    // autoupdate.checkForUpdates always downloads updates immediately 
-    // This method (getUpdate) let's us take a peek to see if there is an update 
-    // available before calling .checkForUpdates
-    const update = await getUpdate(app.getVersion());
-    if (update) {
-      let {name, notes, pubDate:pubDate} = update;
-      pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
-
-      // Ask user if they wish to install now or later
-      dialog.showMessageBox({
-        type: 'info',
-        buttons: ['Install Now', 'Install Later'],
-        message: `Appium Desktop ${name} is available`,
-        detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
-      }, (response) => {
-        if (response === 0) {
-          // If they say yes, get the updates now
-          autoUpdater.checkForUpdates();
-        }
-      });
-    } else {
-      if (fromMenu) {
-        autoUpdater.emit('update-not-available');
-      } else {
-        // If no updates found check for updates every hour
-        await B.delay(60 * 60 * 1000);
-        checkNewUpdates();
-      }
-    }
-  }
-
-  // Inform user when the download is starting and that they'll be notified again when it is complete
-  autoUpdater.on('update-available', () => {
+    // Ask user if they wish to install now or later
     dialog.showMessageBox({
       type: 'info',
-      buttons: ['Ok'],
-      message: 'Update Download Started',
-      detail: 'Update is being downloaded now. You will be notified again when it is complete',
-    });
-  });
-
-  // Handle the unusual case where we checked the updates endpoint, found an update
-  // but then after calling 'checkForUpdates', nothing was there
-  autoUpdater.on('update-not-available', () => {
-    dialog.showMessageBox({
-      type: 'info',
-      buttons: ['Ok'],
-      message: 'No update available',
-      detail: 'Appium Desktop is up-to-date',
-    });
-  });
-
-  // When it's done, ask if user want to restart now or later
-  autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
-    dialog.showMessageBox({
-      type: 'info',
-      buttons: ['Restart Now', 'Later'],
-      message: 'Update Downloaded',
-      detail: `Appium Desktop ${releaseName} has been downloaded. ` +
-        `Must restart to apply the updates ` +
-        `(note: it may take several minutes for Appium Desktop to install and restart)`,
+      buttons: ['Install Now', 'Install Later'],
+      message: `Appium Desktop ${name} is available`,
+      detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
     }, (response) => {
       if (response === 0) {
-        autoUpdater.quitAndInstall();
+        // If they say yes, get the updates now
+        autoUpdater.checkForUpdates();
       }
     });
-  });
-
-  // Handle error case
-  autoUpdater.on('error', (message) => {
-    dialog.showMessageBox({
-      type: 'error',
-      message: 'Could not download update',
-      detail: `Failed to download update. Reason: ${message}`,
-    });
-  });
+  } else {
+    if (fromMenu) {
+      autoUpdater.emit('update-not-available');
+    } else {
+      // If no updates found check for updates every hour
+      await B.delay(60 * 60 * 1000);
+      checkNewUpdates();
+    }
+  }
 }
 
-export { checkNewUpdates };
+// Inform user when the download is starting and that they'll be notified again when it is complete
+autoUpdater.on('update-available', () => {
+  dialog.showMessageBox({
+    type: 'info',
+    buttons: ['Ok'],
+    message: 'Update Download Started',
+    detail: 'Update is being downloaded now. You will be notified again when it is complete',
+  });
+});
+
+// Handle the unusual case where we checked the updates endpoint, found an update
+// but then after calling 'checkForUpdates', nothing was there
+autoUpdater.on('update-not-available', () => {
+  dialog.showMessageBox({
+    type: 'info',
+    buttons: ['Ok'],
+    message: 'No update available',
+    detail: 'Appium Desktop is up-to-date',
+  });
+});
+
+// When it's done, ask if user want to restart now or later
+autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
+  dialog.showMessageBox({
+    type: 'info',
+    buttons: ['Restart Now', 'Later'],
+    message: 'Update Downloaded',
+    detail: `Appium Desktop ${releaseName} has been downloaded. ` +
+      `Must restart to apply the updates ` +
+      `(note: it may take several minutes for Appium Desktop to install and restart)`,
+  }, (response) => {
+    if (response === 0) {
+      autoUpdater.quitAndInstall();
+    }
+  });
+});
+
+// Handle error case
+autoUpdater.on('error', (message) => {
+  dialog.showMessageBox({
+    type: 'error',
+    message: 'Could not download update',
+    detail: `Failed to download update. Reason: ${message}`,
+  });
+});

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -13,85 +13,94 @@ import _ from 'lodash';
 
 const isDev = process.env.NODE_ENV === 'development';
   
-autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
+let checkNewUpdates = _.noop;
 
-/** 
- * Check for new updates
- */
-export async function checkNewUpdates (fromMenu) {
-  // autoupdate.checkForUpdates always downloads updates immediately 
-  // This method (getUpdate) let's us take a peek to see if there is an update 
-  // available before calling .checkForUpdates
-  const update = await getUpdate(app.getVersion());
-  if (update) {
-    let {name, notes, pubDate:pubDate} = update;
-    pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
+if (!isDev) {
 
-    // Ask user if they wish to install now or later
+  autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
+
+  /** 
+   * Check for new updates
+   */
+  checkNewUpdates = async function (fromMenu) {
+    // autoupdate.checkForUpdates always downloads updates immediately 
+    // This method (getUpdate) let's us take a peek to see if there is an update 
+    // available before calling .checkForUpdates
+    const update = await checkUpdate(app.getVersion());
+    if (update) {
+      let {name, notes, pub_date:pubDate} = update;
+      pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
+
+      // Ask user if they wish to install now or later
+      dialog.showMessageBox({
+        type: 'info',
+        buttons: ['Install Now', 'Install Later'],
+        message: `Appium Desktop ${name} is available`,
+        detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
+      }, (response) => {
+        if (response === 0) {
+          // If they say yes, get the updates now
+          autoUpdater.checkForUpdates();
+        }
+      });
+    } else {
+      if (fromMenu) {
+        autoUpdater.emit('update-not-available');
+      } else {
+        // If no updates found check for updates every hour
+        await B.delay(60 * 60 * 1000);
+        checkNewUpdates();
+      }
+    }
+  };
+
+  // Inform user when the download is starting and that they'll be notified again when it is complete
+  autoUpdater.on('update-available', () => {
     dialog.showMessageBox({
       type: 'info',
-      buttons: ['Install Now', 'Install Later'],
-      message: `Appium Desktop ${name} is available`,
-      detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
+      buttons: ['Ok'],
+      message: 'Update Download Started',
+      detail: 'Update is being downloaded now. You will be notified again when it is complete',
+    });
+  });
+
+  // Handle the unusual case where we checked the updates endpoint, found an update
+  // but then after calling 'checkForUpdates', nothing was there
+  autoUpdater.on('update-not-available', () => {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Ok'],
+      message: 'No update available',
+      detail: 'Appium Desktop is up-to-date',
+    });
+  });
+
+  // When it's done, ask if user want to restart now or later
+  autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
+    dialog.showMessageBox({
+      type: 'info',
+      buttons: ['Restart Now', 'Later'],
+      message: 'Update Downloaded',
+      detail: `Appium Desktop ${releaseName} has been downloaded. ` +
+        `Must restart to apply the updates ` +
+        `(note: it may take several minutes for Appium Desktop to install and restart)`,
     }, (response) => {
+      // If they say yes, restart now
       if (response === 0) {
-        // If they say yes, get the updates now
-        autoUpdater.checkForUpdates();
+        autoUpdater.quitAndInstall();
       }
     });
-  } else {
-    if (fromMenu) {
-      autoUpdater.emit('update-not-available');
-    } else {
-      // If no updates found check for updates every hour
-      await B.delay(60 * 60 * 1000);
-      checkNewUpdates();
-    }
-  }
+  });
+
+  // Handle error case
+  autoUpdater.on('error', (message) => {
+    dialog.showMessageBox({
+      type: 'error',
+      message: 'Could not download update',
+      detail: `Failed to download update. Reason: ${message}`,
+    });
+  });
+
 }
 
-// Inform user when the download is starting and that they'll be notified again when it is complete
-autoUpdater.on('update-available', () => {
-  dialog.showMessageBox({
-    type: 'info',
-    buttons: ['Ok'],
-    message: 'Update Download Started',
-    detail: 'Update is being downloaded now. You will be notified again when it is complete',
-  });
-});
-
-// Handle the unusual case where we checked the updates endpoint, found an update
-// but then after calling 'checkForUpdates', nothing was there
-autoUpdater.on('update-not-available', () => {
-  dialog.showMessageBox({
-    type: 'info',
-    buttons: ['Ok'],
-    message: 'No update available',
-    detail: 'Appium Desktop is up-to-date',
-  });
-});
-
-// When it's done, ask if user want to restart now or later
-autoUpdater.on('update-downloaded', (event, releaseNotes, releaseName) => {
-  dialog.showMessageBox({
-    type: 'info',
-    buttons: ['Restart Now', 'Later'],
-    message: 'Update Downloaded',
-    detail: `Appium Desktop ${releaseName} has been downloaded. ` +
-      `Must restart to apply the updates ` +
-      `(note: it may take several minutes for Appium Desktop to install and restart)`,
-  }, (response) => {
-    if (response === 0) {
-      autoUpdater.quitAndInstall();
-    }
-  });
-});
-
-// Handle error case
-autoUpdater.on('error', (message) => {
-  dialog.showMessageBox({
-    type: 'error',
-    message: 'Could not download update',
-    detail: `Failed to download update. Reason: ${message}`,
-  });
-});
+export { checkNewUpdates };

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -157,7 +157,7 @@ export function newSession (caps, attachSessId = null) {
     let desiredCapabilities = caps ? getCapsObject(caps) : null;
     let session = getState().session;
 
-    let host, port, username, accessKey, https, path;
+    let host, port, username, accessKey, https, path, rejectUnauthorized;
     switch (session.serverType) {
       case ServerTypes.local:
         host = session.server.local.hostname;
@@ -174,6 +174,7 @@ export function newSession (caps, attachSessId = null) {
         port = session.server.remote.port;
         path = session.server.remote.path;
         https = session.server.remote.ssl;
+        rejectUnauthorized = !session.server.remote.allowUnauthorized;
         break;
       case ServerTypes.sauce:
         host = 'ondemand.saucelabs.com';
@@ -193,6 +194,7 @@ export function newSession (caps, attachSessId = null) {
           return;
         }
         https = false;
+        rejectUnauthorized = false;
         break;
       case ServerTypes.testobject:
         host = process.env.TESTOBJECT_HOST || `${session.server.testobject.dataCenter || 'us1'}.appium.testobject.com`;
@@ -201,12 +203,14 @@ export function newSession (caps, attachSessId = null) {
         if (caps) {
           desiredCapabilities.testobject_api_key = session.server.testobject.apiKey || process.env.TESTOBJECT_API_KEY;
         }
+        rejectUnauthorized = false;
         break;
       case ServerTypes.headspin:
         host = session.server.headspin.hostname;
         port = session.server.headspin.port;
         path = `/v0/${session.server.headspin.apiKey}/wd/hub`;
         https = true;
+        rejectUnauthorized = false;
         break;
       default:
         break;
@@ -221,7 +225,8 @@ export function newSession (caps, attachSessId = null) {
       path,
       username,
       accessKey,
-      https
+      https,
+      rejectUnauthorized,
     });
 
     dispatch({type: SESSION_LOADING});

--- a/app/renderer/components/Session/AdvancedServerParams.js
+++ b/app/renderer/components/Session/AdvancedServerParams.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react';
+import { Collapse, Form, Checkbox, Col, Input } from 'antd';
+
+const {Panel} = Collapse;
+const FormItem = Form.Item;
+
+export default class AdvancedServerParams extends Component {
+
+
+  render () {
+    const {server, setServerParam} = this.props;
+
+    return <Collapse bordered={true}>
+      <Panel header="Advanced Settings">
+        <Col span={6}>
+          <FormItem>
+            <Checkbox checked={!!server.advanced.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked, 'advanced')}>Allow Unauthorized Certificates</Checkbox>
+          </FormItem>
+        </Col>
+        <Col span={4}>
+          <FormItem>
+            <Checkbox checked={!!server.advanced.useProxy} onChange={(e) => setServerParam('useProxy', e.target.checked, 'advanced')}>Use Proxy</Checkbox>
+          </FormItem>
+        </Col>
+        <Col span={6}>
+          <FormItem>
+            <Input disabled={!server.advanced.useProxy} onChange={(e) => setServerParam('proxy', e.target.value, 'advanced')} placeholder="Proxy URL" value={server.advanced.proxy} />
+          </FormItem>
+        </Col>
+      </Panel>
+    </Collapse>;
+  }
+}

--- a/app/renderer/components/Session/ServerTabCustom.js
+++ b/app/renderer/components/Session/ServerTabCustom.js
@@ -26,11 +26,16 @@ export default class ServerTabCustom extends Component {
           <Input className={SessionStyles.customServerInputLeft} id='customServerPath' placeholder='/wd/hub' addonBefore="Remote Path" value={server.remote.path} onChange={(e) => setServerParam('path', e.target.value)} size="large" />
         </FormItem>
       </Col>
-      <Col span={12}>
+      <Col span={3}>
         <FormItem>
           <Checkbox id='customServerSSL' checked={!!server.remote.ssl} value={server.remote.ssl} onChange={(e) => setServerParam('ssl', e.target.checked)}>SSL</Checkbox>
         </FormItem>
       </Col>
+      {server.remote.ssl && <Col span={9}>
+        <FormItem>
+          <Checkbox id='customServerAllowUnauthorized' checked={!!server.remote.allowUnauthorized} value={server.remote.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked)}>Allow Unauthorized Certificates</Checkbox>
+        </FormItem>
+      </Col>}
     </Form>;
   }
 }

--- a/app/renderer/components/Session/ServerTabHeadspin.js
+++ b/app/renderer/components/Session/ServerTabHeadspin.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Form, Col, Input } from 'antd';
+import { Form, Row, Col, Input } from 'antd';
 import SessionStyles from './Session.css';
 
 const FormItem = Form.Item;
@@ -11,21 +11,25 @@ export default class ServerTabHeadspin extends Component {
     const {server, setServerParam} = this.props;
 
     return <Form>
-      <Col span={12}>
-        <FormItem>
-          <Input className={SessionStyles.customServerInputLeft} id='headspinServerHost' placeholder='xxx.headspin.io' addonBefore="Headspin Host" value={server.headspin.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} size="large" />
-        </FormItem>
-      </Col>
-      <Col span={12}>
-        <FormItem>
-          <Input id='headspinServerPort' placeholder='7200' addonBefore="Headspin Port" value={server.headspin.port} onChange={(e) => setServerParam('port', e.target.value)} size="large" />
-        </FormItem>
-      </Col>
-      <Col span={24}>
-        <FormItem>
-          <Input id='headspinApiKey' type='password' placeholder='f30a3f58c3f842f1aedef457347e1e88' addonBefore="Headspin API Token" value={server.headspin.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} size="large" />
-        </FormItem>
-      </Col>
+      <Row gutter={8}>
+        <Col span={12}>
+          <FormItem>
+            <Input className={SessionStyles.customServerInputLeft} id='headspinServerHost' placeholder='xxx.headspin.io' addonBefore="Headspin Host" value={server.headspin.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} size="large" />
+          </FormItem>
+        </Col>
+        <Col span={12}>
+          <FormItem>
+            <Input id='headspinServerPort' placeholder='7200' addonBefore="Headspin Port" value={server.headspin.port} onChange={(e) => setServerParam('port', e.target.value)} size="large" />
+          </FormItem>
+        </Col>
+      </Row>
+      <Row gutter={8}>
+        <Col span={24}>
+          <FormItem>
+            <Input id='headspinApiKey' type='password' placeholder='f30a3f58c3f842f1aedef457347e1e88' addonBefore="Headspin API Token" value={server.headspin.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} size="large" />
+          </FormItem>
+        </Col>
+      </Row>
     </Form>;
   }
 }

--- a/app/renderer/components/Session/ServerTabSauce.js
+++ b/app/renderer/components/Session/ServerTabSauce.js
@@ -9,33 +9,40 @@ export default class ServerTabSauce extends Component {
     const {server, setServerParam} = this.props;
 
     return <Form>
-      <Row type="flex" justify="space-between" align="top">
-        <Col span={13}>
+      <Row gutter={8}>
+        <Col span={10}>
           <FormItem>
             <Input id='sauceUsername' placeholder={process.env.SAUCE_USERNAME ? 'Using data found in $SAUCE_USERNAME' : 'your-username'} addonBefore="Sauce Username" value={server.sauce.username} onChange={(e) => setServerParam('username', e.target.value)} />
           </FormItem>
+        </Col>
+        <Col span={7}>
           <FormItem>
             <Input id='saucePassword' type='password' placeholder={process.env.SAUCE_ACCESS_KEY ? 'Using data found in $SAUCE_ACCESS_KEY' : 'your-access-key'} addonBefore="Sauce Access Key" value={server.sauce.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
           </FormItem>
         </Col>
-        <Col span={10}>
+        <Col span={7}>
+          <FormItem>
+            <Checkbox checked={!!server.sauce.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked)}>Allow Unauthorized Certificates</Checkbox>
+          </FormItem>
+        </Col>
+      </Row>
+      <Row gutter={8}>
+        <Col span={10} style={{'paddingLeft': '10px'}}>
           <FormItem>
             <Checkbox checked={!!server.sauce.useSCProxy} onChange={(e) => setServerParam('useSCProxy', e.target.checked)}> Proxy through Sauce Connect's Selenium Relay</Checkbox>
           </FormItem>
-          <Row type="flex" justify="space-between" align="top">
-            <Col span={11}>
-              <FormItem>
-                <Input addonBefore="Host" placeholder="localhost" disabled={!server.sauce.useSCProxy} value={server.sauce.scHost} onChange={(e) => setServerParam('scHost', e.target.value)}/>
-              </FormItem>
-            </Col>
-            <Col span={11}>
-              <FormItem>
-                <Input addonBefore="Port" placeholder="4445" disabled={!server.sauce.useSCProxy} value={server.sauce.scPort} onChange={(e) => setServerParam('scPort', e.target.value)} />
-              </FormItem>
-            </Col>
-          </Row>
         </Col>
-      </Row>
+        <Col span={6}>
+          <FormItem>
+            <Input addonBefore="Host" placeholder="localhost" disabled={!server.sauce.useSCProxy} value={server.sauce.scHost} onChange={(e) => setServerParam('scHost', e.target.value)}/>
+          </FormItem>
+        </Col>
+        <Col span={6}>
+          <FormItem>
+            <Input addonBefore="Port" placeholder="4445" disabled={!server.sauce.useSCProxy} value={server.sauce.scPort} onChange={(e) => setServerParam('scPort', e.target.value)} />
+          </FormItem>
+        </Col>
+        </Row>
     </Form>;
   }
 }

--- a/app/renderer/components/Session/ServerTabSauce.js
+++ b/app/renderer/components/Session/ServerTabSauce.js
@@ -10,19 +10,14 @@ export default class ServerTabSauce extends Component {
 
     return <Form>
       <Row gutter={8}>
-        <Col span={10}>
+        <Col span={12}>
           <FormItem>
             <Input id='sauceUsername' placeholder={process.env.SAUCE_USERNAME ? 'Using data found in $SAUCE_USERNAME' : 'your-username'} addonBefore="Sauce Username" value={server.sauce.username} onChange={(e) => setServerParam('username', e.target.value)} />
           </FormItem>
         </Col>
-        <Col span={7}>
+        <Col span={12}>
           <FormItem>
             <Input id='saucePassword' type='password' placeholder={process.env.SAUCE_ACCESS_KEY ? 'Using data found in $SAUCE_ACCESS_KEY' : 'your-access-key'} addonBefore="Sauce Access Key" value={server.sauce.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={7}>
-          <FormItem>
-            <Checkbox checked={!!server.sauce.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked)}>Allow Unauthorized Certificates</Checkbox>
           </FormItem>
         </Col>
       </Row>
@@ -42,7 +37,7 @@ export default class ServerTabSauce extends Component {
             <Input addonBefore="Port" placeholder="4445" disabled={!server.sauce.useSCProxy} value={server.sauce.scPort} onChange={(e) => setServerParam('scPort', e.target.value)} />
           </FormItem>
         </Col>
-        </Row>
+      </Row>
     </Form>;
   }
 }

--- a/app/renderer/components/Session/ServerTabTestobject.js
+++ b/app/renderer/components/Session/ServerTabTestobject.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Form, Input, Select } from 'antd';
+import { Form, Input, Select, Row, Col, Checkbox } from 'antd';
 
 const FormItem = Form.Item;
 
@@ -10,20 +10,33 @@ export default class ServerTabTestobject extends Component {
     const {server, setServerParam} = this.props;
 
     return <Form>
-      <FormItem>
-        <Input id='testObjectPassword' type='password' placeholder={process.env.TESTOBJECT_API_KEY ? 'Using data found in $TESTOBJECT_API_KEY' : 'testobject-api-key'} addonBefore="TestObject API Key" value={server.testobject.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} />
-      </FormItem>
-      <FormItem>
-        <div className="ant-input-wrapper ant-input-group">
-          <div className="ant-input-group-addon">TestObject Data Center</div>
-          <div className="select-container">
-            <Select defaultValue='us1' id='testObjectDataCenter' addonBefore='TestObject Data Center' value={server.testobject.dataCenter} onChange={(value) => setServerParam('dataCenter', value)}>
-              <Select.Option value='us1'>US</Select.Option>
-              <Select.Option value='eu1'>EU</Select.Option>
-            </Select>
-          </div>
-        </div>
-      </FormItem>
+      <Row gutter={8}>
+        <Col span={12}>
+          <FormItem>
+            <Input id='testObjectPassword' type='password' placeholder={process.env.TESTOBJECT_API_KEY ? 'Using data found in $TESTOBJECT_API_KEY' : 'testobject-api-key'} addonBefore="TestObject API Key" value={server.testobject.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} />
+          </FormItem>
+        </Col>
+        <Col span={12}>
+          <FormItem>
+            <Checkbox checked={!!server.testobject.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked)}>Allow Unauthorized Certificates</Checkbox>
+          </FormItem>
+        </Col>
+      </Row>
+      <Row>
+        <Col span={12}>
+          <FormItem>
+            <div className="ant-input-wrapper ant-input-group">
+              <div className="ant-input-group-addon">TestObject Data Center</div>
+              <div className="select-container">
+                <Select defaultValue='us1' id='testObjectDataCenter' addonBefore='TestObject Data Center' value={server.testobject.dataCenter} onChange={(value) => setServerParam('dataCenter', value)}>
+                  <Select.Option value='us1'>US</Select.Option>
+                  <Select.Option value='eu1'>EU</Select.Option>
+                </Select>
+              </div>
+            </div>
+          </FormItem>
+        </Col>
+      </Row>
     </Form>;
   }
 }

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -10,6 +10,7 @@ import ServerTabTestobject from './ServerTabTestobject';
 import ServerTabHeadspin from './ServerTabHeadspin';
 import { Tabs, Button, Spin, Icon } from 'antd';
 import { ServerTypes } from '../../actions/Session';
+import AdvancedServerParams from './AdvancedServerParams';
 import SessionStyles from './Session.css';
 
 const {TabPane} = Tabs;
@@ -58,6 +59,7 @@ export default class Session extends Component {
               <ServerTabHeadspin {...this.props} />
             </TabPane>
           </Tabs>
+          <AdvancedServerParams {...this.props} />
         </div>
 
 

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -25,6 +25,7 @@ const INITIAL_STATE = {
       dataCenter: 'US',
     },
     headspin: {},
+    advanced: {},
   },
   attachSessId: null,
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "teen_process": "^1.11.0",
     "temp": "0.x",
     "uuid": "3.x",
-    "wd": "^1.5.0",
+    "wd": "^1.6.0",
     "xpath": "0.0.24"
   },
   "devDependencies": {


### PR DESCRIPTION
* This is a checkbox that allows users to accept untrusted SSL certificates (for users behind firewall). 
* This checkbox is added to Sauce, TestObject and Headspin (let me know if you think there's a better way of doing this in the UI)
* When set, it turns off the `rejectUnauthorized` http config on `admc/wd`

(https://github.com/appium/appium-desktop/issues/390)