### PR TITLE
Clear the variable names failed

### DIFF
--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -1,5 +1,4 @@
 import Bluebird from 'bluebird';
-import _ from 'lodash';
 import wd from 'wd';
 
 export default class AppiumMethodHandler {
@@ -135,7 +134,7 @@ export default class AppiumMethodHandler {
 
   restart () {
     // Clear the variable names and start over (el1, el2, els1, els2, etc...)
-    for (let elCache of _.toPairs(this.elementCache)) {
+    for (const elCache of Object.values(this.elementCache)) {
       delete elCache.variableName;
     }
 


### PR DESCRIPTION
The _.toPairs return an array of object keyed-value pairs,the variableName delete operation should be
`delete elCache[1].variableName;`.
But I think,appropriate object's property values iteration should be 
`for (const elCache of Object.values(this.elementCache))`.