### PR TITLE
Get Screen Size using WindowSize rather than coordinates of root element

### DIFF
--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -110,7 +110,7 @@ export default class AppiumMethodHandler {
   }
   
   async _getSourceAndScreenshot () {
-    let source, sourceError, screenshot, screenshotError;
+    let source, sourceError, screenshot, screenshotError, windowSize, windowSizeError;
     try {
       source = await this.driver.source();
     } catch (e) {
@@ -128,8 +128,18 @@ export default class AppiumMethodHandler {
       }
       screenshotError = e;
     }
+    
+    try {
+      windowSize = await this.driver.getWindowSize();
+      
+    } catch (e) {
+      if (e.status === 6) {
+        throw e;
+      }
+      windowSizeError = e;
+    }
 
-    return {source, sourceError, screenshot, screenshotError};
+    return {source, sourceError, screenshot, screenshotError, windowSize, windowSizeError};
   }
 
   restart () {

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -311,6 +311,7 @@ function connectClientMethodListener () {
         renderer.send('appium-client-command-response', {
           source: null,
           screenshot: null,
+          windowSize: null,
           uuid,
           result: null
         });

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -110,7 +110,6 @@ export function bindAppium () {
   };
 }
 
-
 // A debounced function that calls findElement and gets info about the element
 const findElement = _.debounce(async function (strategyMap, dispatch, getState, path) {
   for (let [strategy, selector] of strategyMap) {
@@ -188,7 +187,7 @@ export function applyClientMethod (params) {
                       getState().inspector.isRecording;
     try {
       dispatch({type: METHOD_CALL_REQUESTED});
-      let {source, screenshot, result, sourceError, screenshotError, 
+      let {source, screenshot, windowSize, result, sourceError, screenshotError, windowSizeError,
         variableName, variableIndex, strategy, selector} = await callClientMethod(params);
       if (isRecording) {
         // Add 'findAndAssign' line of code. Don't do it for arrays though. Arrays already have 'find' expression
@@ -206,9 +205,11 @@ export function applyClientMethod (params) {
         type: SET_SOURCE_AND_SCREENSHOT, 
         source: source && xmlToJSON(source), 
         sourceXML: source,
-        screenshot, 
+        screenshot,
+        windowSize,
         sourceError, 
         screenshotError,
+        windowSizeError,
       });
       return result;
     } catch (error) {

--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -25,9 +25,8 @@ export default class HighlighterRects extends Component {
     const screenshotEl = this.props.containerEl.querySelector('img');
 
     // now update scale ratio
-    const {x1, x2} = parseCoordinates(this.props.source.children[0].children[0]);
     this.setState({
-      scaleRatio: (x2 - x1) / screenshotEl.offsetWidth
+      scaleRatio: (this.props.windowSize.width / screenshotEl.offsetWidth)
     });
 
   }

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -30,11 +30,9 @@ export default class Screenshot extends Component {
     const screenshotEl = this.containerEl.querySelector('img');
 
     // now update scale ratio
-    const {x1, x2} = parseCoordinates(this.props.source.children[0].children[0]);
     this.setState({
-      scaleRatio: (x2 - x1) / screenshotEl.offsetWidth
+      scaleRatio: (this.props.windowSize.width / screenshotEl.offsetWidth)
     });
-
   }
 
   async handleScreenshotClick () {

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -52,6 +52,8 @@ export default function inspector (state=INITIAL_STATE, action) {
         sourceError: action.sourceError,
         screenshot: action.screenshot,
         screenshotError: action.screenshotError,
+        windowSize: action.windowSize,
+        windowSizeError: action.windowSizeError,
       };
 
     case QUIT_SESSION_REQUESTED:


### PR DESCRIPTION
The root element's size doesn't always reflect the screen size and this will cause coordinates and Highlighter Rectangles to mismatch what's on screen.