### PR TITLE
Prepare for 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node:
 os:
 - linux
 node_js:
-- '7'
+- '9'
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install --no-install-recommends
   -y icnsutils graphicsmagick xz-utils; fi
@@ -15,6 +15,7 @@ addons:
 before_script:
 - node --version
 - npm install
+- npm install -g npm@3
 - npm install -g electron
 - node --version
 - travis_wait 30 npm run package-ci # This command takes a long time, so increased the time limit to 30 minutes (default is 10 minutes)

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ cache:
   - "$HOME/.electron"
   - "$HOME/.cache"
 install:
-- nvm install 7
 - export DISPLAY=':99.0'
 - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 before_script:
 - node --version
 - npm install
-- npm install -g npm@3
+- npm install -g npm@5
 - npm install -g electron
 - node --version
 - travis_wait 30 npm run package-ci # This command takes a long time, so increased the time limit to 30 minutes (default is 10 minutes)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 environment:
-  nodejs_version: "7"
+  nodejs_version: "9"
   GH_TOKEN:
     secure: fyB6CRcrHbroxaBvzN6aPHUEhHGc3ljbbTPtEqruaDVe/iO8/dZn4LOVNS/fAlSX
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm install -g npm@5
   - npm install
 
 test_script:

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "devtron": "1.x",
     "dir-compare": "^1.4.0",
     "electron": "2.0.0",
-    "electron-builder": "^15.6.4",
+    "electron-builder": "^20.0.0",
     "electron-builder-squirrel-windows": "^20.4.0",
     "electron-devtools-installer": "^2.2.3",
     "eslint": "3.x",
@@ -196,7 +196,7 @@
     "npm": ">=3.x"
   },
   "engines": {
-    "node": ">=6.x <=9.x",
-    "npm": ">=3.x <=4.x"
+    "node": "=9.x",
+    "npm": "=5.x"
   }
 }


### PR DESCRIPTION
* Update Appium to 1.8.0
* Update Electron to 2.0.0
* Update electron-builder to 20 and get rid of outdated version hack
* Use NPM 5 on appveyor so we get a flat hierarchy

I'd like to try Travis again on Mac. Maybe the new electron-builder will work