### PR TITLE
Build updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,10 @@
-## [1.5.0](https://github.com/appium/appium-desktop/compare/v1.6.0...v1.5.1) (2018-04-26)
+## [1.6.1](https://github.com/appium/appium-desktop/compare/v1.6.1...v1.5.0) (2018-05-08)
 
 ### Changes
-* Feature: Upgrade bundled Appium version to 1.8.0
-* Feature: Add BrowserStack as server (#510)
+* Feature: Upgrade to Appium 1.8.0
+* Feature: Upgrade Electron to 2.0.0
 * Feature: Add internal session keep-alive (#509)
-* Fix: Upgrade electron 1.7.11 ~> 1.7.13 (#511)
-* Fix: Various code generation fixes (#505)
-* Fix: Remove unneeded form fields from server forms (#487)
-* Fix: Get screenshot Screen Size using WindowSize rather than coordinates of root element
-* Fix: Rename capType from json_object to object prevent exception (#513)
-
-
+* Feature: Add BrowserStack as a cloud provider
 
 ## [1.5.0](https://github.com/appium/appium-desktop/compare/v1.4.1...v1.5.0) (2018-04-02)
 

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -10,6 +10,7 @@ import B from 'bluebird';
 import { checkUpdate } from './update-checker';
 import { getFeedUrl } from './config';
 import _ from 'lodash';
+import env from 'env';
 
 const isDev = process.env.NODE_ENV === 'development';
   
@@ -31,16 +32,24 @@ if (!isDev) {
       let {name, notes, pub_date:pubDate} = update;
       pubDate = moment(pubDate).format('MMM Do YYYY, h:mma');
 
+      let detail = `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`;
+      if (env.NO_AUTO_UPDATE) {
+        detail += `\n\nhttps://www.github.com/appium/appium-desktop/releases/latest`;
+      }
+
+
       // Ask user if they wish to install now or later
       dialog.showMessageBox({
         type: 'info',
-        buttons: ['Install Now', 'Install Later'],
+        buttons: env.NO_AUTO_UPDATE ? ['Ok'] : ['Install Now', 'Install Later'],
         message: `Appium Desktop ${name} is available`,
-        detail: `Release Date: ${pubDate}\n\nRelease Notes: ${notes.replace("*", "\n*")}`,
+        detail,
       }, (response) => {
         if (response === 0) {
           // If they say yes, get the updates now
-          autoUpdater.checkForUpdates();
+          if (!env.NO_AUTO_UPDATE) {
+            autoUpdater.checkForUpdates();
+          }
         }
       });
     } else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ test_script:
   - node --version
   - npm --version
   - npm run package-ci
+  - npm run package-nsis
+  - npm run package-nsis-web
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ test_script:
   - npm --version
   - npm run package-ci
   - npm run package-nsis
-  - npm run package-nsis-web
 
 build: off
 

--- a/env/.env-nsis.js
+++ b/env/.env-nsis.js
@@ -1,0 +1,7 @@
+/**
+ * Env configuration for NSIS target
+ */
+module.exports = { 
+  NO_AUTO_UPDATE: true
+};
+

--- a/env/.env.js
+++ b/env/.env.js
@@ -1,0 +1,3 @@
+module.exports = {
+  
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
     "package-ci": "check-engines && npm run test && npm run build && build --dir && npm run test-e2e && build --publish onTagOrDraft",
+    "package-nsis": "cross-env TARGET=nsis npm run build && build --win nsis --publish onTagOrDraft ",
+    "package-nsis-web": "cross-env TARGET=nsis npm run build && build --win nsis-web --publish onTagOrDraft ",
     "postversion": "git pull --tags && git push && git push --tags"
   },
   "build": {
@@ -77,6 +79,12 @@
     "win": {
       "target": "squirrel",
       "icon": "build/icon.ico"
+    },
+    "nsisWeb": {
+      "oneClick": false
+    },
+    "nsis": {
+      "oneClick": false
     },
     "linux": {
       "target": [

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
     "package-ci": "check-engines && npm run test && npm run build && build --dir && npm run test-e2e && build --publish onTagOrDraft",
-    "package-nsis": "cross-env TARGET=nsis npm run build && build --win nsis --publish onTagOrDraft ",
-    "package-nsis-web": "cross-env TARGET=nsis npm run build && build --win nsis-web --publish onTagOrDraft ",
+    "package-nsis": "cross-env TARGET=nsis npm run build && build --win nsis --publish onTagOrDraft && build --win nsis-web --publish onTagOrDraft",
     "postversion": "git pull --tags && git push && git push --tags"
   },
   "build": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Graphical interface for the Appium server, and an app inspector",
   "repository": {
     "type": "git",

--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -1,5 +1,6 @@
 import webpack from 'webpack';
 import baseConfig from './webpack.config.base';
+import path from 'path';
 
 export default {
   ...baseConfig,
@@ -29,7 +30,10 @@ export default {
   },
 
   resolve: {
-    packageAlias: 'main'
+    packageAlias: 'main',
+    alias: {
+      env: path.resolve(__dirname, 'env', process.env.TARGET ? `.env-${process.env.TARGET}` : '.env'),
+    },
   },
 
   externals: [


### PR DESCRIPTION
* Add nsis builds. Squirrel can be flakey at times and NSIS also allows per-machine builds, however it doesn't support auto-update.
* Add build environments specific to target. This is necessary for NSIS builds so that the UI doesn't show the 'Install Updates' message
* Added 1.6.1 release notes, 1.6.0 had a defect and it's basically just going to be a dead tag now.
* Added NSIS builds to AppVeyor