### PR TITLE
Add debugging to dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "dev",
+        "type": "node",
+        "request": "launch",
+        "cwd": "${workspaceRoot}",
+        "runtimeExecutable": "npm",
+        "env": {
+          "NODE_ENV": "development"
+        },
+        "runtimeArgs": [
+            "run-script", "dev"
+        ],
+        "port": 5858
+      }
+    ]
+  }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,9 +86,9 @@ npm run e2e
 ### Debugging
 
 #### Renderer
-The renderer uses Chromium and can be debugged using Chrome DevTools. When you run in dev (`npm run dev`) the Chrome DevTools
-window opens up on startup. To open it again, after it has been closed, right click on the window and select `Inspect Element` 
-to open it up.
+* The renderer uses Chromium and can be debugged using Chrome DevTools the same way a webpage is debugged
+* When you run dev (`npm run dev`) the Chrome DevTools window is opened on startup. 
+* To open it again, after it has been closed, right click on the window and select `Inspect Element` 
 
 #### Main
 * In Chrome Dev Tools
@@ -101,7 +101,7 @@ to open it up.
 * In VSCode
   * In the debug tab, run 'dev'
   * Set breakpoints directly in VSCode
-* For reference see on NodeJS debugging see
+* For reference on NodeJS debugging see:
   * https://electronjs.org/docs/tutorial/debugging-main-process-vscode
   * https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,29 @@ To run the e2e tests call
 npm run e2e
 ```
 
+### Debugging
+
+#### Renderer
+The renderer uses Chromium and can be debugged using Chrome DevTools. When you run in dev (`npm run dev`) the Chrome DevTools
+window opens up on startup. To open it again, after it has been closed, right click on the window and select `Inspect Element` 
+to open it up.
+
+#### Main
+* In Chrome Dev Tools
+  * Run dev (`npm run dev`). This sets an --inspect port at 5858
+  * Running in dev sets up an inspector port at 5858
+  * Open chrome://inspect in your chrome browser
+  * Click `Open dedicated DevTools for Node`
+  * Add a connection `localhost:5858`
+  * Start inspecting code under other tabs
+* In VSCode
+  * In the debug tab, run 'dev'
+  * Set breakpoints directly in VSCode
+* For reference see on NodeJS debugging see
+  * https://electronjs.org/docs/tutorial/debugging-main-process-vscode
+  * https://medium.com/@paul_irish/debugging-node-js-nightlies-with-chrome-devtools-7c4a1b95ae27
+
+
 ### Packaging and Releasing
 
 Appium Desktop uses [Electron Builder](https://github.com/electron-userland/electron-builder/) to build app. Read this document for instructions on how to set up your local environment so that you can build and package the app: https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "npm run build-main && npm run build-renderer",
     "clean": "rimraf node_modules && npm install",
     "start": "cross-env NODE_ENV=production electron ./",
-    "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r ./node_modules/babel-register -r ./node_modules/babel-polyfill ./app/main/main.development --color",
+    "start-hot": "cross-env HOT=1 NODE_ENV=development electron -r ./node_modules/babel-register -r ./node_modules/babel-polyfill --inspect=5858 ./app/main/main.development --color",
     "postinstall": "node node_modules/fbjs-scripts/node/check-dev-engines.js package.json",
     "dev": "concurrently --kill-others \"npm run hot-server\" \"npm run start-hot\" --color",
     "dev-wrong-folder": "cross-env WRONG_FOLDER=true npm run dev",


### PR DESCRIPTION
* Added .vscode configuration so that you can debug directly in VSCode
* Added --inspect flag to `npm run dev` to make that work
* The --inspect flag also makes it possible to debug in Chrome DevTools
* Added documentation in CONTRIBUTING.md to explain how it works
* I've tested this in both and it works perfectly, it even respects source-maps so that you can debug src code instead of transpiled code