### PR TITLE
Fix: .env properly loads based on target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
   - "$HOME/.electron"
   - "$HOME/.cache"
 install:
-- npm install
+- npm ci
 - export DISPLAY=':99.0'
 - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 dist: trusty

--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -10,7 +10,7 @@ import B from 'bluebird';
 import { checkUpdate } from './update-checker';
 import { getFeedUrl } from './config';
 import _ from 'lodash';
-import env from 'env';
+import env from '../../../env/.env';
 
 const isDev = process.env.NODE_ENV === 'development';
   

--- a/env/.env.js
+++ b/env/.env.js
@@ -1,3 +1,7 @@
-module.exports = {
-  
+let env = {};
+
+if (process.env.TARGET) {
+  env = require(`./.env-${process.env.TARGET}`);
 }
+
+export default env;

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test-unit": "mocha --compilers js:babel-core/register ./test/unit",
     "lint": "eslint app test *.js",
     "hot-server": "node -r ./node_modules/babel-register server.js --color",
-    "build-main": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors --color",
-    "build-renderer": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors --color",
+    "build-main": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --display=minimal --config webpack.config.electron.js --progress --profile --colors --color",
+    "build-renderer": "cross-env NODE_ENV=production node -r ./node_modules/babel-register ./node_modules/webpack/bin/webpack --display=minimal --config webpack.config.production.js --progress --profile --colors --color",
     "build": "npm run build-main && npm run build-renderer",
     "clean": "rimraf node_modules && npm install",
     "start": "cross-env NODE_ENV=production electron ./",
@@ -136,6 +136,7 @@
     "xpath": "0.0.24"
   },
   "devDependencies": {
+    "7zip": "0.0.6",
     "appium-fake-driver": "^0.4.0",
     "asar": "^0.14.0",
     "asyncbox": "^2.3.2",

--- a/webpack.config.electron.js
+++ b/webpack.config.electron.js
@@ -16,6 +16,9 @@ export default {
   },
 
   plugins: [
+    new webpack.EnvironmentPlugin([
+      'TARGET'
+    ]),
     new webpack.BannerPlugin(
       'require("source-map-support").install();',
       { raw: true, entryOnly: false }


### PR DESCRIPTION
* Used the ENVIRONMENT_PLUGIN
* Export environment config based on plugin. Right now .nsis is the only alternative
* Also silenced webpack so we don't see the long package installation messages
* Also changed npm install to npm ci for Travis so that it gets the packages defined in `package-lock.json`