### PR TITLE
Don't set 'interactions not available' until we've tried all strategies

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -139,9 +139,9 @@ const findElement = _.debounce(async function (strategyMap, dispatch, getState, 
     if (elementId && getState().inspector.selectedElementPath === path) {
       return dispatch({type: SET_SELECTED_ELEMENT_ID, elementId, variableName, variableType});
     }
-
-    return dispatch({type: SET_INTERACTIONS_NOT_AVAILABLE});
   }
+
+  return dispatch({type: SET_INTERACTIONS_NOT_AVAILABLE});
 }, 1000);
 
 export function selectElement (path) {


### PR DESCRIPTION
* When an element is 'selected' it tries locating that element by a strategy that's inferred from the source xml
* Previously, it was trying one and then showing 'Element Not Interactable' if the first didn't work
* Now, it tries them _all_ and then shows 'Element Not Interactable' if none of them work