### PR TITLE
Add cloud provider visibility menu

### DIFF
--- a/app/main/main.development.js
+++ b/app/main/main.development.js
@@ -87,11 +87,11 @@ app.on('ready', async () => {
   });
 
   if (process.platform === 'darwin') {
-    template = menuTemplates.mac(mainWindow);
+    template = await menuTemplates.mac(mainWindow);
     menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);
   } else {
-    template = menuTemplates.other(mainWindow);
+    template = await menuTemplates.other(mainWindow);
     menu = Menu.buildFromTemplate(template);
     mainWindow.setMenu(menu);
   }

--- a/app/main/menus.js
+++ b/app/main/menus.js
@@ -2,14 +2,13 @@ import { app, shell, dialog } from 'electron';
 import _ from 'lodash';
 import { createNewSessionWindow } from './appium';
 import { checkNewUpdates } from './auto-updater';
-import CloudProvider from '../shared/cloud-providers';
+import CloudProviders from '../shared/cloud-providers';
 
 let menuTemplates = {mac: {}, other: {}};
 
 async function getCloudProvidersViewMenu () {
-  const providers = CloudProvider.getProviders();
   const providersMenu = [];
-  for (let provider of _.values(providers)) {
+  for (let provider of _.values(CloudProviders)) {
     providersMenu.push({
       label: provider.label,
       type: 'checkbox',

--- a/app/shared/cloud-providers/config.js
+++ b/app/shared/cloud-providers/config.js
@@ -1,0 +1,14 @@
+export default {
+  saucelabs: {
+    label: 'Sauce Labs',
+  },
+  testobject: {
+    label: 'TestObject'
+  },
+  browserstack: {
+    label: 'BrowserStack',
+  },
+  headspin: {
+    label: 'HeadSpin',
+  },
+}

--- a/app/shared/cloud-providers/config.js
+++ b/app/shared/cloud-providers/config.js
@@ -11,4 +11,4 @@ export default {
   headspin: {
     label: 'HeadSpin',
   },
-}
+};

--- a/app/shared/cloud-providers/index.js
+++ b/app/shared/cloud-providers/index.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import settings from 'electron-settings';
 import config from './config';
 
-export default class CloudProvider {
+class CloudProvider {
 
   constructor (providerName, providerData) {
     const {label} = providerData;
@@ -29,12 +29,12 @@ export default class CloudProvider {
     await settings.set(visibilityKey, isVisible);
   }
 
-  static getProviders () {
-    const providers = {};
-    for (let [providerName, providerData] of _.toPairs(config)) {
-      providers[providerName] = new CloudProvider(providerName, providerData);
-    }
-    return providers;
-  }
-
 }
+
+
+const providers = {};
+for (let [providerName, providerData] of _.toPairs(config)) {
+  providers[providerName] = new CloudProvider(providerName, providerData);
+}
+
+export default providers;

--- a/app/shared/cloud-providers/index.js
+++ b/app/shared/cloud-providers/index.js
@@ -1,0 +1,40 @@
+import _ from 'lodash';
+import settings from 'electron-settings';
+import config from './config';
+
+export default class CloudProvider {
+
+  constructor (providerName, providerData) {
+    const {label} = providerData;
+    this.name = providerName;
+    this.label = label;
+  }
+
+  getSettingsKey (keyName) {
+    return `Providers.${this.name}.${keyName}`;
+  }
+
+  async isVisible () {
+    const visibilityKey = this.getSettingsKey('visible');
+    const isVisible = await settings.get(visibilityKey);
+    if (!_.isBoolean(isVisible)) {
+      await this.setVisible(true);
+      return true;
+    }
+    return isVisible;
+  }
+
+  async setVisible (isVisible = true) {
+    const visibilityKey = this.getSettingsKey('visible');
+    await settings.set(visibilityKey, isVisible);
+  }
+
+  static getProviders () {
+    const providers = {};
+    for (let [providerName, providerData] of _.toPairs(config)) {
+      providers[providerName] = new CloudProvider(providerName, providerData);
+    }
+    return providers;
+  }
+
+}


### PR DESCRIPTION
(Replaces an older PR)

* Add a submenu in 'View' that lets you toggle which cloud providers are visible

![screen shot 2018-07-04 at 4 31 31 pm](https://user-images.githubusercontent.com/852574/42296221-d122a776-7fa7-11e8-9c31-60fb1439c1d9.png)

* Toggling the submenu items changes the state using `electron-settings` so that the user preferences are persisted across sessions
* Created a `shared` folder that has the logic for cloud providers, eventually I'd like to move all of the cloud provider logic there so that there's only one place where we configure it

(cc: @llaskin)