### PR TITLE
ANDROID_HOME set from in UI

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -159,7 +159,6 @@ export function createNewSessionWindow (win) {
     title: "Start Session",
     backgroundColor: "#f2f2f2",
     frame: "customButtonsOnHover",
-    titleBarStyle: 'hidden',
     webPreferences: {
       devTools: true
     }
@@ -395,6 +394,16 @@ function connectOpenConfig () {
     configHTMLPath = configHTMLPath.replace("\\", "/");
     configHTMLPath += '#/config';
     win.loadURL(`file://${configHTMLPath}`);
+    win.webContents.on('context-menu', (e, props) => {
+      const {x, y} = props;
+  
+      Menu.buildFromTemplate([{
+        label: 'Inspect element',
+        click () {
+          win.inspectElement(x, y);
+        }
+      }]).popup(win);
+    });
     win.show();
   });
 }

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -374,6 +374,31 @@ function connectMoveToApplicationsFolder () {
   });
 }
 
+function connectOpenConfig () {
+  ipcMain.on('appium-open-config', (/*evt*/) => {
+    const win = new BrowserWindow({
+      width: 1080,
+      minWidth: 1080,
+      height: 570,
+      minHeight: 570,
+      title: "Start Session",
+      backgroundColor: "#f2f2f2",
+      frame: "customButtonsOnHover",
+      titleBarStyle: 'hidden',
+      webPreferences: {
+        devTools: true
+      }
+    });
+
+    let configHTMLPath = path.resolve(__dirname,  isDev ? '..' : 'app', 'renderer', 'index.html');
+    // on Windows we'll get backslashes, but we don't want these for a browser URL, so replace
+    configHTMLPath = configHTMLPath.replace("\\", "/");
+    configHTMLPath += '#/config';
+    win.loadURL(`file://${configHTMLPath}`);
+    win.show();
+  });
+}
+
 function initializeIpc (win) {
   // listen for 'start-server' from the renderer
   connectStartServer(win);
@@ -389,6 +414,7 @@ function initializeIpc (win) {
   connectMoveToApplicationsFolder();
   connectKeepAlive();
   connectClearLogFile();
+  connectOpenConfig();
 
   setTimeout(checkNewUpdates, 10000);
 }

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -408,6 +408,21 @@ function connectOpenConfig () {
   });
 }
 
+function connectGetEnv () {
+  ipcMain.on('appium-get-env', (event) => {
+    event.sender.send('appium-env', {
+      defaultEnvironmentVariables: process.env,
+      savedEnvironmentVariables: settings.get('ENV', {}),
+    });
+  });
+}
+
+function connectSetEnv () {
+  ipcMain.on('appium-set-env', (event, data) => {
+    settings.set('ENV', data.env);
+  });
+}
+
 function initializeIpc (win) {
   // listen for 'start-server' from the renderer
   connectStartServer(win);
@@ -424,6 +439,8 @@ function initializeIpc (win) {
   connectKeepAlive();
   connectClearLogFile();
   connectOpenConfig();
+  connectGetEnv();
+  connectSetEnv();
 
   setTimeout(checkNewUpdates, 10000);
 }

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -355,12 +355,16 @@ function connectMoveToApplicationsFolder () {
   });
 }
 
+export function createNewConfigWindow (win) {
+  openBrowserWindow('config', {
+    title: "Config",
+    parent: win,
+  });
+}
+
 function connectOpenConfig (win) {
   ipcMain.on('appium-open-config', () => {
-    openBrowserWindow('config', {
-      title: "Config",
-      parent: win,
-    });
+    createNewConfigWindow(win);
   });
 }
 

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -359,6 +359,8 @@ export function createNewConfigWindow (win) {
   openBrowserWindow('config', {
     title: "Config",
     parent: win,
+    width: 1080 / 2,
+    height: 1080 / 4,
   });
 }
 
@@ -383,7 +385,7 @@ function connectSaveEnv () {
     const env = _.pickBy(environmentVariables, _.identity);
 
     await settings.set('ENV', env);
-    setEnv();
+    await setEnv();
     event.sender.send('appium-save-env-done');
   });
 }

--- a/app/main/helpers.js
+++ b/app/main/helpers.js
@@ -1,0 +1,53 @@
+import { BrowserWindow, Menu } from 'electron';
+import path from 'path';
+
+const isDev = process.env.NODE_ENV === 'development';
+
+export function openBrowserWindow (route, opts) {
+  const defaultOpts = {
+    width: 1080,
+    minWidth: 1080,
+    height: 570,
+    minHeight: 570,
+    backgroundColor: "#f2f2f2",
+    frame: "customButtonsOnHover",
+    webPreferences: {
+      devTools: true
+    }
+  };
+
+  let win = new BrowserWindow({
+    ...defaultOpts,
+    ...opts,
+  });
+
+  // note that __dirname changes based on whether we're in dev or prod;
+  // in dev it's the actual dirname of the file, in prod it's the root
+  // of the project (where main.js is built), so switch accordingly
+  let htmlPath = path.resolve(__dirname,  isDev ? '..' : 'app', 'renderer', 'index.html');
+  
+  // on Windows we'll get backslashes, but we don't want these for a browser URL, so replace
+  htmlPath = htmlPath.replace("\\", "/");
+  htmlPath += `#/${route}`;
+  win.loadURL(`file://${htmlPath}`);
+  win.show();
+
+  // If it's dev, go ahead and open up the dev tools automatically
+  if (isDev) {
+    win.openDevTools();
+  }
+
+  // Make 'devTools' available on right click
+  win.webContents.on('context-menu', (e, props) => {
+    const {x, y} = props;
+
+    Menu.buildFromTemplate([{
+      label: 'Inspect element',
+      click () {
+        win.inspectElement(x, y);
+      }
+    }]).popup(win);
+  });
+
+  return win;
+}

--- a/app/main/menus.js
+++ b/app/main/menus.js
@@ -1,6 +1,6 @@
 import { app, shell, dialog } from 'electron';
 import _ from 'lodash';
-import { createNewSessionWindow } from './appium';
+import { createNewSessionWindow, createNewConfigWindow} from './appium';
 import { checkNewUpdates } from './auto-updater';
 import CloudProviders from '../shared/cloud-providers';
 
@@ -39,6 +39,11 @@ function macMenuAppium (mainWindow) {
       accelerator: 'Command+N',
       click () {
         createNewSessionWindow(mainWindow);
+      }
+    }, {
+      label: 'Configurations',
+      click () {
+        createNewConfigWindow(mainWindow);
       }
     }, {
       type: 'separator'

--- a/app/renderer/actions/Config.js
+++ b/app/renderer/actions/Config.js
@@ -1,7 +1,30 @@
+import { ipcRenderer } from 'electron';
+
 export const SET_ENVIRONMENT_VARIABLE = 'SET_ENVIRONMENT_VARIABLE';
+export const SET_ENVIRONMENT_VARIABLES = 'SET_ENVIRONMENT_VARIABLES';
+export const GET_ENVIRONMENT_VARIABLES = 'GET_ENVIRONMENT_VARIABLES';
+export const SAVE_ENVIRONMENT_VARIABLES = 'SAVE_ENVIRONMENT_VARIABLES';
 
 export function setEnvironmentVariable (name, value) {
   return (dispatch) => {
     dispatch({type: SET_ENVIRONMENT_VARIABLE, name, value});
+  };
+}
+
+export function getEnvironmentVariables () {
+  return (dispatch) => {
+    dispatch({type: GET_ENVIRONMENT_VARIABLES});
+    ipcRenderer.send('appium-get-env');
+    ipcRenderer.once('appium-env', (evt, env) => {
+      const {defaultEnvironmentVariables, savedEnvironmentVariables} = env;
+      dispatch({type: SET_ENVIRONMENT_VARIABLES, defaultEnvironmentVariables, savedEnvironmentVariables});
+    });
+  };
+}
+
+export function saveEnvironmentVariables () {
+  return (dispatch, getState) => {
+    const {environmentVariables:env} = getState();
+    //ipcRenderer.send('appium-set-env', env);
   };
 }

--- a/app/renderer/actions/Config.js
+++ b/app/renderer/actions/Config.js
@@ -21,10 +21,3 @@ export function getEnvironmentVariables () {
     });
   };
 }
-
-export function saveEnvironmentVariables () {
-  return (dispatch, getState) => {
-    const {environmentVariables:env} = getState();
-    //ipcRenderer.send('appium-set-env', env);
-  };
-}

--- a/app/renderer/actions/Config.js
+++ b/app/renderer/actions/Config.js
@@ -1,8 +1,7 @@
-export const NAME_OF_ACTION_1 = 'NAME_OF_ACTION_1';
-export const NAME_OF_ACTION_2 = 'NAME_OF_ACTION_2';
+export const SET_ENVIRONMENT_VARIABLE = 'SET_ENVIRONMENT_VARIABLE';
 
-export function someAction () {
-  return async (/*dispatch, getState*/) => {
-
+export function setEnvironmentVariable (name, value) {
+  return (dispatch) => {
+    dispatch({type: SET_ENVIRONMENT_VARIABLE, name, value});
   };
 }

--- a/app/renderer/actions/Config.js
+++ b/app/renderer/actions/Config.js
@@ -1,0 +1,8 @@
+export const NAME_OF_ACTION_1 = 'NAME_OF_ACTION_1';
+export const NAME_OF_ACTION_2 = 'NAME_OF_ACTION_2';
+
+export function someAction () {
+  return async (/*dispatch, getState*/) => {
+
+  };
+}

--- a/app/renderer/actions/Stub.js
+++ b/app/renderer/actions/Stub.js
@@ -1,0 +1,8 @@
+export const NAME_OF_ACTION_1 = 'NAME_OF_ACTION_1';
+export const NAME_OF_ACTION_2 = 'NAME_OF_ACTION_2';
+
+export function someAction () {
+  return async (/*dispatch, getState*/) => {
+
+  };
+}

--- a/app/renderer/components/Config/Config.css
+++ b/app/renderer/components/Config/Config.css
@@ -1,0 +1,10 @@
+.container {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  padding: 4em 2em 2em 2em;
+}
+
+.row {
+  margin-bottom: 16px;
+}

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -4,26 +4,29 @@ import styles from './Config.css';
 
 export default class Config extends Component {
 
+  componentWillMount () {
+    this.props.getEnvironmentVariables();
+  }
+
   render () {
-    const {setEnvironmentVariable} = this.props;
+    const {setEnvironmentVariable, environmentVariables:env, defaultEnvironmentVariables} = this.props;
+
+    const ENV_VARIABLE_NAMES = [
+      'ANDROID_HOME', 'JAVA_HOME'
+    ];
 
     return <div className={styles.container}>
       <h3>Environment Variables</h3>
-      <Row className={styles.row} gutter={16}>
-        <Col span={24}>
-          <Input addonBefore="ANDROID_HOME" onChange={(evt) => setEnvironmentVariable('ANDROID_HOME', evt.target.value)} />
-        </Col>
-      </Row>
-      <Row className={styles.row} gutter={16}>
-        <Col span={24}>
-          <Input addonBefore="JAVA_HOME" onChange={(evt) => setEnvironmentVariable('JAVA_HOME', evt.target.value)} />
-        </Col>
-      </Row>
-      <Row className={styles.row} gutter={16}>
-        <Col span={24}>
-          <Input addonBefore="CARTHAGE" onChange={(evt) => setEnvironmentVariable('CARTHAGE', evt.target.value)} />
-        </Col>
-      </Row>
+      {ENV_VARIABLE_NAMES.map((ENV_NAME) => (
+        <Row key={ENV_NAME} className={styles.row} gutter={16}>
+          <Col span={24}>
+            <Input addonBefore={ENV_NAME} 
+              placeholder={defaultEnvironmentVariables[ENV_NAME]}
+              onChange={(evt) => setEnvironmentVariable(ENV_NAME, evt.target.value)} 
+              value={env[ENV_NAME]}  />
+          </Col>
+        </Row>
+      ))}
     </div>;
   }
 }

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -1,6 +1,9 @@
+import { ipcRenderer, remote } from 'electron';
 import React, { Component } from 'react';
-import { Input, Row, Col } from 'antd';
+import { Input, Row, Col, Button } from 'antd';
 import styles from './Config.css';
+
+const {app} = remote;
 
 export default class Config extends Component {
 
@@ -8,8 +11,17 @@ export default class Config extends Component {
     this.props.getEnvironmentVariables();
   }
 
+  saveAndRestart () {
+    const {environmentVariables} = this.props;
+    ipcRenderer.send('appium-save-env', environmentVariables);
+    ipcRenderer.once('appium-save-env-done', () => {
+      app.relaunch();
+      app.exit();
+    });
+  }
+
   render () {
-    const {setEnvironmentVariable, environmentVariables:env, defaultEnvironmentVariables} = this.props;
+    const {setEnvironmentVariable, environmentVariables, defaultEnvironmentVariables} = this.props;
 
     const ENV_VARIABLE_NAMES = [
       'ANDROID_HOME', 'JAVA_HOME'
@@ -23,10 +35,15 @@ export default class Config extends Component {
             <Input addonBefore={ENV_NAME} 
               placeholder={defaultEnvironmentVariables[ENV_NAME]}
               onChange={(evt) => setEnvironmentVariable(ENV_NAME, evt.target.value)} 
-              value={env[ENV_NAME]}  />
+              value={environmentVariables[ENV_NAME]}  />
           </Col>
         </Row>
       ))}
+      <Row>
+        <Col span={24}>
+          <Button onClick={() => this.saveAndRestart()}>Save and Restart</Button>
+        </Col>
+      </Row>
     </div>;
   }
 }

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -5,21 +5,23 @@ import styles from './Config.css';
 export default class Config extends Component {
 
   render () {
+    const {setEnvironmentVariable} = this.props;
+
     return <div className={styles.container}>
       <h3>Environment Variables</h3>
       <Row className={styles.row} gutter={16}>
         <Col span={24}>
-          <Input addonBefore="ANDROID_HOME" />
+          <Input addonBefore="ANDROID_HOME" onChange={(evt) => setEnvironmentVariable('ANDROID_HOME', evt.target.value)} />
         </Col>
       </Row>
       <Row className={styles.row} gutter={16}>
         <Col span={24}>
-          <Input addonBefore="JAVA_HOME" />
+          <Input addonBefore="JAVA_HOME" onChange={(evt) => setEnvironmentVariable('JAVA_HOME', evt.target.value)} />
         </Col>
       </Row>
       <Row className={styles.row} gutter={16}>
         <Col span={24}>
-          <Input addonBefore="CARTHAGE" />
+          <Input addonBefore="CARTHAGE" onChange={(evt) => setEnvironmentVariable('CARTHAGE', evt.target.value)} />
         </Col>
       </Row>
     </div>;

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -1,12 +1,27 @@
 import React, { Component } from 'react';
+import { Input, Row, Col } from 'antd';
+import styles from './Config.css';
 
-export default class Stub extends Component {
+export default class Config extends Component {
 
   render () {
-    const { someProp } = this.props;
-    
-    return <div>
-      HELLO WORLD!
+    return <div className={styles.container}>
+      <h3>Environment Variables</h3>
+      <Row className={styles.row} gutter={16}>
+        <Col span={24}>
+          <Input addonBefore="ANDROID_HOME" />
+        </Col>
+      </Row>
+      <Row className={styles.row} gutter={16}>
+        <Col span={24}>
+          <Input addonBefore="JAVA_HOME" />
+        </Col>
+      </Row>
+      <Row className={styles.row} gutter={16}>
+        <Col span={24}>
+          <Input addonBefore="CARTHAGE" />
+        </Col>
+      </Row>
     </div>;
   }
 }

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Input, Row, Col, Button } from 'antd';
 import styles from './Config.css';
 
-const {app} = remote;
+const {app, dialog, getCurrentWindow} = remote;
 
 export default class Config extends Component {
 
@@ -15,8 +15,18 @@ export default class Config extends Component {
     const {environmentVariables} = this.props;
     ipcRenderer.send('appium-save-env', environmentVariables);
     ipcRenderer.once('appium-save-env-done', () => {
-      app.relaunch();
-      app.exit();
+      const message = `Application must be restarted for changes to take effect`;
+      const dialogOptions = {type: 'info', buttons: ['Restart Now', 'Restart Later'], message};
+      dialog.showMessageBox(dialogOptions, (response) => {
+        if (response === 0) {
+          // If 'Restart Now' restart the application
+          app.relaunch();
+          app.exit();
+        } else {
+          // ...otherwise, just close the current window
+          getCurrentWindow().close();
+        }
+      });
     });
   }
 

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+
+export default class Stub extends Component {
+
+  render () {
+    const { someProp } = this.props;
+    
+    return <div>
+      HELLO WORLD!
+    </div>;
+  }
+}

--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -3,6 +3,10 @@ import React, { Component } from 'react';
 import { Input, Row, Col, Button } from 'antd';
 import styles from './Config.css';
 
+const ENV_VARIABLE_NAMES = [
+  'ANDROID_HOME', 'JAVA_HOME'
+];
+
 const {app, dialog, getCurrentWindow} = remote;
 
 export default class Config extends Component {
@@ -32,10 +36,6 @@ export default class Config extends Component {
 
   render () {
     const {setEnvironmentVariable, environmentVariables, defaultEnvironmentVariables} = this.props;
-
-    const ENV_VARIABLE_NAMES = [
-      'ANDROID_HOME', 'JAVA_HOME'
-    ];
 
     return <div className={styles.container}>
       <h3>Environment Variables</h3>

--- a/app/renderer/components/StartServer/StartButton.css
+++ b/app/renderer/components/StartServer/StartButton.css
@@ -6,3 +6,10 @@
     font-size: 1.3em !important;
 }
 
+.configButton {
+    width: 100%;
+    margin-top: 10px;
+    padding: 10px !important;
+    height: auto;
+    font-size: 1.3em !important;
+}

--- a/app/renderer/components/StartServer/StartButton.js
+++ b/app/renderer/components/StartServer/StartButton.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import { Button } from 'antd';
+import { Button, Icon } from 'antd';
+import { ipcRenderer } from 'electron';
 
 import styles from './StartButton.css';
 
@@ -16,6 +17,10 @@ export default class StartButton extends Component {
 
   noop (evt) {
     evt.preventDefault();
+  }
+
+  openConfig () {
+    ipcRenderer.send('appium-open-config');
   }
 
   render () {
@@ -35,6 +40,11 @@ export default class StartButton extends Component {
           {serverStarting ? "Starting..." : `Start Server v${serverVersion}`}
         </Button>
         <input type="submit" hidden={true} />
+        <Button id='configBtn'
+          className={styles.configButton}
+          onClick={() => this.openConfig()}>
+          Edit Configurations <Icon type="setting" />
+        </Button>
       </div>
     );
   }

--- a/app/renderer/components/StartServer/StartServer.js
+++ b/app/renderer/components/StartServer/StartServer.js
@@ -1,4 +1,3 @@
-import { ipcRenderer } from 'electron';
 import React, { Component, PropTypes } from 'react';
 import { Button } from 'antd';
 
@@ -30,10 +29,6 @@ export default class StartServer extends Component {
     }
   }
 
-  openConfig () {
-    ipcRenderer.send('appium-open-config');
-  }
-
   render () {
     const {tabId, switchTab} = this.props;
     return (
@@ -53,7 +48,6 @@ export default class StartServer extends Component {
               >Presets</Button>
             </Button.Group>
           </div>
-          <Button onClick={() => this.openConfig()}>Config</Button>
           {this.displayTab()}
         </div>
       </div>

--- a/app/renderer/components/StartServer/StartServer.js
+++ b/app/renderer/components/StartServer/StartServer.js
@@ -1,3 +1,4 @@
+import { ipcRenderer } from 'electron';
 import React, { Component, PropTypes } from 'react';
 import { Button } from 'antd';
 
@@ -29,8 +30,12 @@ export default class StartServer extends Component {
     }
   }
 
+  openConfig () {
+    ipcRenderer.send('appium-open-config');
+  }
+
   render () {
-    const {tabId, switchTab, serverVersion} = this.props;
+    const {tabId, switchTab} = this.props;
     return (
       <div className={styles.container}>
         <div className={styles.formAndLogo}>
@@ -48,6 +53,7 @@ export default class StartServer extends Component {
               >Presets</Button>
             </Button.Group>
           </div>
+          <Button onClick={() => this.openConfig()}>Config</Button>
           {this.displayTab()}
         </div>
       </div>

--- a/app/renderer/components/Stub.js
+++ b/app/renderer/components/Stub.js
@@ -1,0 +1,12 @@
+import React, { Component } from 'react';
+
+export default class Stub extends Component {
+
+  render () {
+    const { someProp } = this.props;
+    
+    return <div>
+      Hello {someProp}!
+    </div>;
+  }
+}

--- a/app/renderer/containers/ConfigPage.js
+++ b/app/renderer/containers/ConfigPage.js
@@ -4,7 +4,7 @@ import * as ConfigActions from '../actions/Config';
 import ConfigPage from '../components/Config/Config';
 
 function mapStateToProps (state) {
-  return state.inspector;
+  return state.config;
 }
 
 function mapDispatchToProps (dispatch) {

--- a/app/renderer/containers/ConfigPage.js
+++ b/app/renderer/containers/ConfigPage.js
@@ -1,0 +1,14 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as ConfigActions from '../actions/Config';
+import ConfigPage from '../components/Config/Config';
+
+function mapStateToProps (state) {
+  return state.inspector;
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators(ConfigActions, dispatch);
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(ConfigPage);

--- a/app/renderer/reducers/Config.js
+++ b/app/renderer/reducers/Config.js
@@ -1,0 +1,24 @@
+import { 
+  SET_ENVIRONMENT_VARIABLE
+} from '../actions/Config';
+
+
+const INITIAL_STATE = {
+  environmentVariables: {},
+};
+
+export default function inspector (state=INITIAL_STATE, action) {
+  switch (action.type) {
+    case SET_ENVIRONMENT_VARIABLE:
+      return {
+        ...state,
+        environmentVariables: {
+          ...state.environmentVariables,
+          [action.name]: action.value,
+        }
+      };
+
+    default:
+      return {...state};
+  }
+}

--- a/app/renderer/reducers/Config.js
+++ b/app/renderer/reducers/Config.js
@@ -1,10 +1,11 @@
 import { 
-  SET_ENVIRONMENT_VARIABLE
+  SET_ENVIRONMENT_VARIABLE, SET_ENVIRONMENT_VARIABLES
 } from '../actions/Config';
 
 
 const INITIAL_STATE = {
   environmentVariables: {},
+  defaultEnvironmentVariables: {},
 };
 
 export default function inspector (state=INITIAL_STATE, action) {
@@ -16,6 +17,13 @@ export default function inspector (state=INITIAL_STATE, action) {
           ...state.environmentVariables,
           [action.name]: action.value,
         }
+      };
+
+    case SET_ENVIRONMENT_VARIABLES:
+      return {
+        ...state,
+        environmentVariables: action.savedEnvironmentVariables,
+        defaultEnvironmentVariables: action.defaultEnvironmentVariables,
       };
 
     default:

--- a/app/renderer/reducers/Config.js
+++ b/app/renderer/reducers/Config.js
@@ -22,7 +22,7 @@ export default function inspector (state=INITIAL_STATE, action) {
     case SET_ENVIRONMENT_VARIABLES:
       return {
         ...state,
-        environmentVariables: action.savedEnvironmentVariables,
+        environmentVariables: action.savedEnvironmentVariables || {},
         defaultEnvironmentVariables: action.defaultEnvironmentVariables,
       };
 

--- a/app/renderer/reducers/Stub.js
+++ b/app/renderer/reducers/Stub.js
@@ -1,0 +1,28 @@
+import { 
+  NAME_OF_ACTION_1, NAME_OF_ACTION_2
+} from '../actions/Stub';
+
+
+const INITIAL_STATE = {
+  someVariable: false,
+  someOtherVariable: 'hello',
+};
+
+export default function inspector (state=INITIAL_STATE, action) {
+  switch (action.type) {
+    case NAME_OF_ACTION_1:
+      return {
+        ...state,
+        someVariable: true
+      };
+
+    case NAME_OF_ACTION_2:
+      return {
+        ...state,
+        someOtherVariable: 'world',
+      };
+
+    default:
+      return {...state};
+  }
+}

--- a/app/renderer/reducers/index.js
+++ b/app/renderer/reducers/index.js
@@ -5,6 +5,7 @@ import serverMonitor from './ServerMonitor';
 import session from './Session';
 import inspector from './Inspector';
 import updater from './Updater';
+import config from './Config';
 
 // create our root reducer
 const rootReducer = combineReducers({
@@ -14,6 +15,7 @@ const rootReducer = combineReducers({
   session,
   inspector,
   updater,
+  config,
 });
 
 export default rootReducer;

--- a/app/renderer/routes.js
+++ b/app/renderer/routes.js
@@ -5,6 +5,7 @@ import StartServerPage from './containers/StartServerPage';
 import ServerMonitorPage from './containers/ServerMonitorPage';
 import SessionPage from './containers/SessionPage';
 import InspectorPage from './containers/InspectorPage';
+import ConfigPage from './containers/ConfigPage';
 
 export default (
   <Route path="/" component={App}>
@@ -12,5 +13,6 @@ export default (
     <Route path="monitor" component={ServerMonitorPage} />
     <Route path="session" component={SessionPage} />
     <Route path="inspector" component={InspectorPage} />
+    <Route path="config" component={ConfigPage} />
   </Route>
 );


### PR DESCRIPTION
* Added a 'Config' window that is either opened from menu or from the start server page
* Added form that sets environment variables JAVA_HOME and ANDROID_HOME
* Shows defaults as whatever 'appium-desktop' finds inside of `process.env` originally
* When these are saved, saves it to appium-settings
* When app is loaded for first time, `process.env` is extended with these saved env vars
* When config is 'Saved' the user is asked to 'Restart Now' for changes to take effect

* Other

  * Added 'Stubs' for actions, reducers and components for cutting-and-pasting purposes later on
  * Moved browser window opener to a helper method

* This is how it looks, we'll probably want to change it to something more subtle
![screen shot 2018-07-24 at 4 12 52 pm](https://user-images.githubusercontent.com/852574/43170965-aeabf43a-8f5c-11e8-87a2-a16b22ace4f3.png)


![screen shot 2018-07-24 at 4 19 54 pm](https://user-images.githubusercontent.com/852574/43171099-70539f48-8f5d-11e8-87d6-c7059b0fe780.png)