### PR TITLE
Fix two typos in Browserstack tab; fixes env var usage

### DIFF
--- a/app/renderer/components/Session/ServerTabBrowserstack.js
+++ b/app/renderer/components/Session/ServerTabBrowserstack.js
@@ -13,14 +13,14 @@ export default class ServerTabBrowserstack extends Component {
       <Row gutter={8}>
         <Col span={12}>
           <FormItem>
-            <Input id='browserstackUsername' placeholder={process.env.BROWSERSTACK_USERNME ? 'Using data found in $BROWSERSTACK_USERNAME' : 'your-username'} addonBefore="BrowserStack Username" value={server.browserstack.username} onChange={(e) => setServerParam('username', e.target.value)} />
+            <Input id='browserstackUsername' placeholder={process.env.BROWSERSTACK_USERNAME ? 'Using data found in $BROWSERSTACK_USERNAME' : 'your-username'} addonBefore="BrowserStack Username" value={server.browserstack.username} onChange={(e) => setServerParam('username', e.target.value)} />
           </FormItem>
         </Col>
       </Row>
       <Row gutter={8}>
         <Col span={12}>
           <FormItem>
-            <Input id='browserstackPassword' type='password' placeholder={process.env.BOWSERSTACK_ACCESS_KEY ? 'Using data found in $BROWSERSTACK_ACCESS_KEY' : 'your-access-key'} addonBefore="BrowserStack Access Key" value={server.browserstack.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+            <Input id='browserstackPassword' type='password' placeholder={process.env.BROWSERSTACK_ACCESS_KEY ? 'Using data found in $BROWSERSTACK_ACCESS_KEY' : 'your-access-key'} addonBefore="BrowserStack Access Key" value={server.browserstack.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
           </FormItem>
         </Col>
       </Row>


### PR DESCRIPTION
While working on https://github.com/appium/appium-desktop/pull/594 , I noticed that the Browserstack tab has a couple of typos.

The typos in the env vars would currently cause the UI not to show that the env vars are detected.
This PR should fix it and help the people using Browserstack :)