### PR TITLE
Added React Native testID to Strategy Mappings

### DIFF
--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -32,6 +32,7 @@ const STRATEGY_MAPPINGS = [
   ['name', 'accessibility id'],
   ['content-desc', 'accessibility id'],
   ['id', 'id'],
+  ['rntestid', 'id'],
   ['resource-id', 'id'],
 ];
 


### PR DESCRIPTION
You.i Engine now supports React Native and we've added support for it's testID to be used in Appium.
https://facebook.github.io/react-native/docs/view#testid

`rntestid` was added to the selector mapping and uses `id` as it's search strategy.