### PR TITLE
Remove getParser code

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -120,7 +120,7 @@ function connectGetDefaultArgs () {
     evt.returnValue = getDefaultArgs();
   });
 
-  ipcMain.on('get-args-metadata', (evt) => {
+  ipcMain.on('get-args-metadata', (/*evt*/) => {
     // If argv isn't defined, set it now. If argv[1] isn't defined, set it to empty string.
     // If process.argv[1] is undefined, calling getParser() will break because argparse expects it to be a string
     if (!process.argv) {
@@ -130,10 +130,14 @@ function connectGetDefaultArgs () {
     if (!process.argv[1]) {
       process.argv[1] = '';
     }
+    // Temporarily remove this feature until 'getParser' issue (https://github.com/appium/appium/issues/11320) has been fixed 
+    /*const backupPathResolve = path.resolve;
+    path.resolve = () => "node_modules/appium/package.json";
     let defArgs = Object.keys(getDefaultArgs());
     evt.returnValue = getParser().rawArgs
                         .filter((a) => defArgs.indexOf(a[1].dest) !== -1)
                         .map((a) => a[1]);
+    path.resolve = backupPathResolve;*/
   });
 }
 

--- a/app/renderer/reducers/StartServer.js
+++ b/app/renderer/reducers/StartServer.js
@@ -7,7 +7,9 @@ import { ipcRenderer } from 'electron';
 import { version as SERVER_VERSION } from 'appium/package.json';
 
 export const DEFAULT_ARGS = ipcRenderer.sendSync('get-default-args');
-export const ARG_DATA = ipcRenderer.sendSync('get-args-metadata');
+
+// TODO: Add this back when 'getParser' issue (https://github.com/appium/appium/issues/11320) has been fixed
+//export const ARG_DATA = ipcRenderer.sendSync('get-args-metadata');
 
 const initialState = {
   serverArgs: {...DEFAULT_ARGS},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1114,6 +1114,7 @@
             "gulp-replace": "^0.6.1",
             "gulp-sourcemaps": "^2.2.0",
             "gulp-util": "^3.0.7",
+            "istanbul": "next",
             "lodash": "^4.0.1",
             "mocha": "^5.1.1",
             "moment": "^2.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1114,7 +1114,6 @@
             "gulp-replace": "^0.6.1",
             "gulp-sourcemaps": "^2.2.0",
             "gulp-util": "^3.0.7",
-            "istanbul": "next",
             "lodash": "^4.0.1",
             "mocha": "^5.1.1",
             "moment": "^2.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Graphical interface for the Appium server, and an app inspector",
   "repository": {
     "type": "git",

--- a/test/integration/update-checker.integration-test.js
+++ b/test/integration/update-checker.integration-test.js
@@ -7,7 +7,7 @@ import { checkUpdate } from '../../app/main/auto-updater/update-checker';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('updateChecker', function () {
+describe.skip('updateChecker', function () {
   let latestVersion;
 
   before(async function () {

--- a/test/integration/update-checker.integration-test.js
+++ b/test/integration/update-checker.integration-test.js
@@ -7,7 +7,7 @@ import { checkUpdate } from '../../app/main/auto-updater/update-checker';
 chai.should();
 chai.use(chaiAsPromised);
 
-describe.skip('updateChecker', function () {
+describe('updateChecker', function () {
   let latestVersion;
 
   before(async function () {


### PR DESCRIPTION
* This [issue](https://github.com/appium/appium/issues/11320) causes Appium Desktop to break when it tries calling 'getParser'
* Temporary workaround is to just comment out the code that calls 'getParser' because it doesn't actually get used
* I could remove it completely, but I wanted to check first to see if it's there for a reason