### PR TITLE
default custom server port to 4723 which is the value in placeholder

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -173,7 +173,7 @@ export function newSession (caps, attachSessId = null) {
         break;
       case ServerTypes.remote:
         host = session.server.remote.hostname;
-        port = session.server.remote.port;
+        port = session.server.remote.port || 4723;
         path = session.server.remote.path;
         https = session.server.remote.ssl;
         break;

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -172,7 +172,7 @@ export function newSession (caps, attachSessId = null) {
         port = session.server.local.port;
         break;
       case ServerTypes.remote:
-        host = session.server.remote.hostname;
+        host = session.server.remote.hostname || '127.0.0.1';
         port = session.server.remote.port || 4723;
         path = session.server.remote.path;
         https = session.server.remote.ssl;


### PR DESCRIPTION
The default values (`hostname`: `127.0.0.1` and `port`: `4723` described in the placeholders) are not applied which throws a `Could not start session`.

