### PR TITLE
Make lookahead for "." lazy

### DIFF
--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -9,7 +9,7 @@ class JsWdIoFramework extends Framework {
   chainifyCode (code) {
     return code
       .replace(/let .+ = /g, '')
-      .replace(/(\n|^)(driver|el.+)\./g, '\n.')
+      .replace(/(\n|^)(driver|el[0-9]+)\./g, '\n.')
       .replace(/;\n/g, '\n');
   }
 


### PR DESCRIPTION
* In the chainify, don't accept _any_ character after `el`.... only accept integers
* Previous implementation, it was looking ahead to the last instance of `.` and if you had an email in a string it would clip it up until the `. in `email@email.com`