### PR TITLE
Use 3rd party prop types for React

### DIFF
--- a/app/renderer/components/ServerMonitor/ServerMonitor.js
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Button, Tooltip } from 'antd';
 import { STATUS_RUNNING, STATUS_STOPPING,
          STATUS_STOPPED } from '../../reducers/ServerMonitor';

--- a/app/renderer/components/StartServer/DeletePresetButton.js
+++ b/app/renderer/components/StartServer/DeletePresetButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Button } from 'antd';
 
 import styles from './StartButton.css';

--- a/app/renderer/components/StartServer/SavePresetButton.js
+++ b/app/renderer/components/StartServer/SavePresetButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Button } from 'antd';
 
 import styles from './StartButton.css';

--- a/app/renderer/components/StartServer/StartButton.js
+++ b/app/renderer/components/StartServer/StartButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Button, Icon } from 'antd';
 import { ipcRenderer } from 'electron';
 

--- a/app/renderer/components/StartServer/StartServer.js
+++ b/app/renderer/components/StartServer/StartServer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Button } from 'antd';
 
 import { propTypes } from './shared';

--- a/app/renderer/components/StartServer/shared.js
+++ b/app/renderer/components/StartServer/shared.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { DEFAULT_ARGS } from '../../reducers/StartServer';
 
 export const propTypes = {

--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class App extends Component {
   render () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "lodash": "4.x",
     "moment": "^2.20.1",
     "postcss": "^7.0.4",
+    "prop-types": "^15.6.2",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-redux": "^5.1.0",


### PR DESCRIPTION
First step before upgrading to React 16 is to use 3rd party PropTypes (internal PropTypes are deprecated in 16)