### PR TITLE
Don't run E2E tests on Mac (for now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 - npm --version
 script:
 - travis_wait 30 npm run package-ci # This command takes a long time, so increased the time limit to 30 minutes (default is 10 minutes)
+- npm run test-e2e
 after_script:
 - greenkeeper-lockfile-upload
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ test_script:
   - node --version
   - npm --version
   - npm run package-ci
+  - npm run test-e2e
   - npm run package-nsis
 
 build: off

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "package-linux": "npm run build && build --linux",
     "package-all": "npm run build && build -mwl",
     "package-nsis": "cross-env TARGET=nsis npm run build && build --win nsis --publish onTagOrDraft && build --win nsis-web --publish onTagOrDraft",
-    "package-ci": "node ./check-engines package.json && npm run clean && npm run build && npm run test && npm run sentry-release && build --publish onTagOrDraft && npm run test-e2e",
+    "package-ci": "node ./check-engines package.json && npm run clean && npm run build && npm run test && npm run sentry-release && build --publish onTagOrDraft",
     "postinstall": "node ./check-engines package.json package.json && rimraf node_modules/jimp/browser && node ./sentry-set-version",
     "postversion": "git pull --tags && git push && git push --tags",
     "pre-commit": "npm run lint && mocha --reporter dot ./test/unit",


### PR DESCRIPTION
E2E tests inexplicably stopped working on Azure Pipelines (I even attempted re-running old, formerly passing builds, with no problems)

Stopping running E2E tests on Azure until it gets sorted out.