### PR TITLE
Fix filePath dialogs

### DIFF
--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -1,8 +1,20 @@
 import React, { Component } from 'react';
 import { Switch, Input, Icon } from 'antd';
 import SessionStyles from './Session.css';
+import {remote} from 'electron';
+const {dialog} = remote;
+
 
 export default class NewSessionForm extends Component {
+
+  getLocalFilePath (success) {
+    dialog.showOpenDialog((filepath) => {
+      if (filepath) {
+        success(filepath);
+      }
+    });
+    this.handleSetType = this.handleSetType.bind(this);
+  }
 
   render () {
     const {cap, onSetCapabilityParam, isEditingDesiredCaps, id} = this.props;

--- a/app/renderer/components/Session/NewSessionForm.js
+++ b/app/renderer/components/Session/NewSessionForm.js
@@ -1,23 +1,12 @@
 import React, { Component } from 'react';
 import { Button, Input, Modal, Form, Row, Col, Select } from 'antd';
-import { remote } from 'electron';
 import FormattedCaps from './FormattedCaps';
 import CapabilityControl from './CapabilityControl';
 import SessionStyles from './Session.css';
-const {dialog} = remote;
 const {Item: FormItem} = Form;
 const {Option} = Select;
 
 export default class NewSessionForm extends Component {
-
-  getLocalFilePath (success) {
-    dialog.showOpenDialog((filepath) => {
-      if (filepath) {
-        success(filepath);
-      }
-    });
-    this.handleSetType = this.handleSetType.bind(this);
-  }
 
   /**
    * Callback when the type of a dcap is changed


### PR DESCRIPTION
**Bug**: filePath dialogs were getting `this.getLocalFilePath() is undefined` errors.

**Fix**: Moved getLocalFilePath declaration to CapabilityControl.js