### PR TITLE
Add a separate menu item for translations stuff

### DIFF
--- a/app/main/menus.js
+++ b/app/main/menus.js
@@ -192,6 +192,11 @@ function macMenuHelp () {
       click () {
         shell.openExternal('https://github.com/appium/appium-desktop/issues');
       }
+    }, {
+      label: i18n.t('Add Or Improve Translations'),
+      click () {
+        shell.openExternal('https://crowdin.com/project/appium-desktop');
+      }
     }]
   };
 }

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -17,6 +17,7 @@
   "Documentation": "Documentation",
   "Search Issues": "Search Issues",
   "About Appium": "About Appium",
+  "Add Or Improve Translations": "Add Or Improve Translations",
   "Check for updates": "Check for updates",
   "New Session Window…": "New Session Window…",
   "Configurations…": "Configurations…",


### PR DESCRIPTION
Make it easier for people to find the place where they can add/improve Appium Desktop translations