### PR TITLE
fix: inspector CSS

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -66,6 +66,14 @@
     flex-flow: column;
 }
 
+.inspector-main .interaction-tab-container :global(.ant-tabs) {
+    height: 100%;
+}
+
+.inspector-main .interaction-tab-container :global(.ant-tabs-content) {
+    height: 100%;
+}
+
 .inspector-main .interaction-tab-container :global(.action-row) {
     display: flex;
 }

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -105,7 +105,7 @@
     height: 100%;
 }
 
-.inspector-main .tree-container :global(ul) {
+.inspector-main .tree-container :global(ul.ant-tree) {
     height: 100%;
     overflow: auto;
 }

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -89,8 +89,12 @@
     height: 100%;
 }
 .inspector-main .interaction-tab-container :global(.action-col) {
-    flex: '1 1 0';
-    width: 0;
+    min-width: 50%;
+    max-width: 50%;
+}
+
+.inspector-main .interaction-tab-container :global(.ant-card) {
+    height: 100%;
 }
 
 .inspector-main .interaction-tab-container :global(.ant-tree) {

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -86,8 +86,8 @@
 
 .inspector-main .interaction-tab-container :global(.action-row) {
     display: flex;
+    height: 100%;
 }
-
 .inspector-main .interaction-tab-container :global(.action-col) {
     flex: '1 1 0';
     width: 0;

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -96,6 +96,15 @@
     overflow: auto;
 }
 
+.inspector-main .tree-container {
+    height: 100%;
+}
+
+.inspector-main .tree-container :global(ul) {
+    height: 100%;
+    overflow: auto;
+}
+
 .inspector-main .interaction-tab-container .scroll-buttons {
     position: absolute;
     bottom: 0;

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -66,6 +66,15 @@
     flex-flow: column;
 }
 
+.inspector-main :global(.ant-card-head) {
+    max-height: 48px;
+}
+
+.inspector-main :global(.ant-card-body) {
+    height: calc(100% - 48px);
+    padding-bottom: 48px;
+}
+
 .inspector-main .interaction-tab-container :global(.ant-tabs) {
     height: 100%;
 }
@@ -126,7 +135,6 @@
 .inspector-main .recorded-actions :global(.ant-card-body),
 .inspector-main .interaction-tab-card :global(.ant-card-body) {
     overflow: scroll;
-    height: 100%;
 }
 
 .inspector-main .interaction-tab-card {

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -64,6 +64,7 @@
     padding-left: 1em;
     display: flex;
     flex-flow: column;
+    height: 100%;
 }
 
 .inspector-main :global(.ant-card-head) {
@@ -130,11 +131,9 @@
 
 .inspector-main .recorded-actions {
     margin-bottom: 12px;
-}
-
-.inspector-main .recorded-actions {
+    max-height: 40%;
+    min-height: 30%;
     flex: 1;
-    min-height: 150px;
 }
 
 .inspector-main .recorded-actions :global(.ant-btn-group) {

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -74,13 +74,16 @@ export default class Inspector extends Component {
         <Tabs activeKey={selectedInteractionMode} size="small" onChange={(tab) => selectInteractionMode(tab)}>
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
             <div className='action-row'>
-              <div className='col'>
+              <div className='col' style={{minWidth: '50%', maxWidth: '50%'}}>
                 <Card
                   title={<span><Icon type="file-text" /> {t('App Source')}</span>}>
                   <Source {...this.props} />
                 </Card>
               </div>
-              <div id='selectedElementContainer' className='action-col' className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']}`}>
+              <div id='selectedElementContainer' 
+                className='action-col' 
+                className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']}`}
+                style={{minWidth: '50%', maxWidth: '50%'}}>
                 <Card
                   title={<span><Icon type="tag-o" /> {t('selectedElement')}</span>}
                   className={InspectorStyles['selected-element-card']}>

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -75,7 +75,7 @@ export default class Inspector extends Component {
           size="small"
           onChange={(tab) => selectInteractionMode(tab)}>
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
-            <div className='action-row' style={{minHeight: '100%'}}>
+            <div className='action-row' style={{minHeight: '100%', maxHeight: '100%'}}>
               <div className='col' style={{minWidth: '50%', maxWidth: '50%'}}>
                 <Card style={{height: '100%'}}
                   title={<span><Icon type="file-text" /> {t('App Source')}</span>}>

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -67,7 +67,7 @@ export default class Inspector extends Component {
           </Spin>
         }
       </div>
-      <div id='sourceTreeContainer' style={{height: '100%'}} className={InspectorStyles['interaction-tab-container']} >
+      <div id='sourceTreeContainer' className={InspectorStyles['interaction-tab-container']} >
         {showRecord &&
           <RecordedActions {...this.props} />
         }
@@ -75,15 +75,14 @@ export default class Inspector extends Component {
           size="small"
           onChange={(tab) => selectInteractionMode(tab)}>
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
-            <div className='action-row' style={{minHeight: '100%', maxHeight: '100%'}}>
-              <div className='col' style={{minWidth: '50%', maxWidth: '50%'}}>
+            <div className='action-row' style={{height: '100%'}}>
+              <div style={{minWidth: '50%', maxWidth: '50%'}}>
                 <Card style={{height: '100%'}}
                   title={<span><Icon type="file-text" /> {t('App Source')}</span>}>
                   <Source {...this.props} />
                 </Card>
               </div>
               <div id='selectedElementContainer'
-                className='action-col'
                 className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']}`}
                 style={{minWidth: '50%', maxWidth: '50%'}}>
                 <Card style={{height: '100%'}}

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -76,17 +76,14 @@ export default class Inspector extends Component {
           onChange={(tab) => selectInteractionMode(tab)}>
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
             <div className='action-row'>
-              <div style={{minWidth: '50%', maxWidth: '50%'}}>
-                <Card style={{height: '100%'}}
-                  title={<span><Icon type="file-text" /> {t('App Source')}</span>}>
+              <div className='action-col'>
+                <Card title={<span><Icon type="file-text" /> {t('App Source')}</span>}>
                   <Source {...this.props} />
                 </Card>
               </div>
               <div id='selectedElementContainer'
-                className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']}`}
-                style={{minWidth: '50%', maxWidth: '50%'}}>
-                <Card style={{height: '100%'}}
-                  title={<span><Icon type="tag-o" /> {t('selectedElement')}</span>}
+                className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']} action-col`}>
+                <Card title={<span><Icon type="tag-o" /> {t('selectedElement')}</span>}
                   className={InspectorStyles['selected-element-card']}>
                   {path && <SelectedElement {...this.props}/>}
                   {!path && <i>{t('selectElementInSource')}</i>}

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -67,24 +67,26 @@ export default class Inspector extends Component {
           </Spin>
         }
       </div>
-      <div id='sourceTreeContainer' className={InspectorStyles['interaction-tab-container']} >
+      <div id='sourceTreeContainer' style={{height: '100%'}} className={InspectorStyles['interaction-tab-container']} >
         {showRecord &&
           <RecordedActions {...this.props} />
         }
-        <Tabs activeKey={selectedInteractionMode} size="small" onChange={(tab) => selectInteractionMode(tab)}>
+        <Tabs activeKey={selectedInteractionMode}
+          size="small"
+          onChange={(tab) => selectInteractionMode(tab)}>
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
-            <div className='action-row'>
+            <div className='action-row' style={{minHeight: '100%'}}>
               <div className='col' style={{minWidth: '50%', maxWidth: '50%'}}>
-                <Card
+                <Card style={{height: '100%'}}
                   title={<span><Icon type="file-text" /> {t('App Source')}</span>}>
                   <Source {...this.props} />
                 </Card>
               </div>
-              <div id='selectedElementContainer' 
-                className='action-col' 
+              <div id='selectedElementContainer'
+                className='action-col'
                 className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']}`}
                 style={{minWidth: '50%', maxWidth: '50%'}}>
-                <Card
+                <Card style={{height: '100%'}}
                   title={<span><Icon type="tag-o" /> {t('selectedElement')}</span>}
                   className={InspectorStyles['selected-element-card']}>
                   {path && <SelectedElement {...this.props}/>}

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -75,7 +75,7 @@ export default class Inspector extends Component {
           size="small"
           onChange={(tab) => selectInteractionMode(tab)}>
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
-            <div className='action-row' style={{height: '100%'}}>
+            <div className='action-row'>
               <div style={{minWidth: '50%', maxWidth: '50%'}}>
                 <Card style={{height: '100%'}}
                   title={<span><Icon type="file-text" /> {t('App Source')}</span>}>

--- a/app/renderer/components/Inspector/RecordedActions.js
+++ b/app/renderer/components/Inspector/RecordedActions.js
@@ -90,6 +90,7 @@ class RecordedActions extends Component {
     const highlightedCode = this.code(false);
 
     return <Card title={<span><Icon type="code-o"/> {t('Recorder')}</span>}
+      style={{maxHeight: '50%', minHeight: '40%'}}
       className={InspectorStyles['recorded-actions']}
       extra={this.actionBar()}
     >

--- a/app/renderer/components/Inspector/RecordedActions.js
+++ b/app/renderer/components/Inspector/RecordedActions.js
@@ -90,7 +90,7 @@ class RecordedActions extends Component {
     const highlightedCode = this.code(false);
 
     return <Card title={<span><Icon type="code-o"/> {t('Recorder')}</span>}
-      style={{maxHeight: '50%', minHeight: '40%'}}
+      style={{maxHeight: '40%', minHeight: '40%'}}
       className={InspectorStyles['recorded-actions']}
       extra={this.actionBar()}
     >

--- a/app/renderer/components/Inspector/RecordedActions.js
+++ b/app/renderer/components/Inspector/RecordedActions.js
@@ -90,7 +90,6 @@ class RecordedActions extends Component {
     const highlightedCode = this.code(false);
 
     return <Card title={<span><Icon type="code-o"/> {t('Recorder')}</span>}
-      style={{maxHeight: '40%', minHeight: '40%'}}
       className={InspectorStyles['recorded-actions']}
       extra={this.actionBar()}
     >


### PR DESCRIPTION
The last commit to add the `Actions` tab messed up the CSS. This fixes it all.

![Screen Shot 2019-03-18 at 1 16 28 PM](https://user-images.githubusercontent.com/852574/54560698-2c563700-4980-11e9-8b4b-7966f5f726ea.png)
