### PR TITLE
Bump up no activity limit to 24 hours

### DIFF
--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -7,8 +7,8 @@ import { SCREENSHOT_INTERACTION_MODE } from '../renderer/components/Inspector/sh
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 const KEEP_ALIVE_PING_INTERVAL = 5 * 1000;
-const NO_NEW_COMMAND_LIMIT = isDevelopment ? 30 * 1000 : 5 * 60 * 1000;
-const WAIT_FOR_USER_KEEP_ALIVE = 30 * 1000;
+const NO_NEW_COMMAND_LIMIT = isDevelopment ? 30 * 1000 : 24 * 60 * 60 * 1000; // Set timeout to 24 hours
+const WAIT_FOR_USER_KEEP_ALIVE = 60 * 60 * 1000; // Give user 1 hour to reply
 
 export default class AppiumMethodHandler {
   constructor (driver, sender) {


### PR DESCRIPTION
Right now sessions prompt users after 30 minutes to keep sessions alive and they're only given 5 minutes to respond to the prompt.

This doesn't work well for people who are multitasking between running an Appium session and doing other work.

This PR bumps up the number to 24 hours with 1 hour to respond to the prompt. 

I think we can trust Appium users to use their cloud concurrency responsibly.