### PR TITLE
Get source, screenshot and windowSize concurrently

### DIFF
--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -171,11 +171,15 @@ export default class AppiumMethodHandler {
     return await new Bluebird((resolve) => {
       let res = {};
 
-      // Resolve when we have source, screenshot and windowSize (or there errors)
+      // Resolve when we have source/sourceError, screenshot/screenshotError and windowSize/windowSizeError
       // NOTE: Couldn't use Promise.all here because Promise.all fails when it encounters just one error. In this
       // case we need it to finish all of the promises and get either the response or the error for each
       const checkShouldResolve = () => {
-        if ((res.source || res.sourceError) && (res.screenshot || res.screenshotError) && (res.windowSize || res.windowSizeError)) {
+        if (
+          (res.source || res.sourceError) &&
+          (res.screenshot || res.screenshotError) &&
+          (res.windowSize || res.windowSizeError)
+        ) {
           resolve(res);
         }
       };


### PR DESCRIPTION
* The current way of getting source, screenshot and windowSize is calling each one-after-the-other
* This PR makes it so that they all get called at once and then the promise resolve once we have a result for all three (whether it's successful or an error). Should give a pretty noticeable performance bump.
* Pardon the Promises abomination. `Promise.all` doesn't support waiting for all promises to resolve. I needed a solution that completes all three of the promises and then sends the result back.
* Also note, I wanted to use `finally` to call `checkShouldResolve`, but there's a race condition that causes `finally` to sometimes be called before `then` or `catch`.