### PR TITLE
fix: Stop ignoring result for element location/size

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -300,13 +300,10 @@ function connectClientMethodListener () {
           }
         }
 
-        if (ignoreResult) {
-          res = {};
-        }
-
         renderer.send('appium-client-command-response', {
           ...res,
           methodName,
+          ignoreResult,
           uuid,
         });
       }

--- a/app/renderer/actions/shared.js
+++ b/app/renderer/actions/shared.js
@@ -1,5 +1,6 @@
 import { ipcRenderer } from 'electron';
 import { notification } from 'antd';
+import { util } from 'appium-support';
 import i18n from '../../configs/i18next.config.renderer';
 import _ from 'lodash';
 import UUID from 'uuid';
@@ -23,7 +24,7 @@ export function bindClient () {
 
     const truncatedResult = _.truncate(JSON.stringify(res), {length: 2000});
 
-    if (!_.isNull(res) && !_.isUndefined(res) && !resp.ignoreResult) {
+    if (util.hasValue(res) && !resp.ignoreResult) {
       notification.success({
         message: i18n.t('methodCallResult', {methodName}),
         description: i18n.t('commandWasReturnedWithResult', {result: truncatedResult}),

--- a/app/renderer/actions/shared.js
+++ b/app/renderer/actions/shared.js
@@ -23,7 +23,7 @@ export function bindClient () {
 
     const truncatedResult = _.truncate(JSON.stringify(res), {length: 2000});
 
-    if (!_.isNull(res) && !_.isUndefined(res)) {
+    if (!_.isNull(res) && !_.isUndefined(res) && !resp.ignoreResult) {
       notification.success({
         message: i18n.t('methodCallResult', {methodName}),
         description: i18n.t('commandWasReturnedWithResult', {result: truncatedResult}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -7461,7 +7461,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -8103,8 +8102,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8125,14 +8123,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8147,20 +8143,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8277,8 +8270,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8290,7 +8282,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8305,7 +8296,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -8313,14 +8303,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8339,7 +8327,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8420,8 +8407,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8433,7 +8419,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8519,8 +8504,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8556,7 +8540,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8576,7 +8559,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8620,14 +8602,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13463,8 +13443,7 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",


### PR DESCRIPTION
The 'ignoreResult' flag was causing the result to not be sent back to the renderer process. This was done because there's some cases where we don't want the result to be displayed using "notification" but this is a problem for highlighting an element because it wasn't getting the result.
This changes it so that 'ignoreResult' still sends the result back to the renderer but skips the notification if it's 'ignoreResult=true'.