### PR TITLE
make sure to save server type change even without setting change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Certificates.p12
 .cache/
 .idea/
 junit-test-results.xml
+junit-testresults.xml

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -29,13 +29,13 @@ export default class Session extends Component {
     })();
   }
 
-  handleSelectServerTab (tab) {
+  async handleSelectServerTab (tab) {
     const {changeServerType, addCloudProvider} = this.props;
     if (tab === ADD_CLOUD_PROVIDER) {
       addCloudProvider();
       return;
     }
-    changeServerType(tab);
+    await changeServerType(tab);
   }
 
   removeCloudProvider (providerName) {


### PR DESCRIPTION
also, fix minor bug where user could have cloud provider saved as server type,
but then it is removed from the visible providers list. default to remote in
that case.