### PR TITLE
make configurable get running sessions path

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -321,9 +321,9 @@ function connectClientMethodListener () {
 }
 
 const getCurrentSessions = _.debounce(async (evt, data) => {
-  const {host, port, path, ssl} = data;
+  const {host, port, path: appiumPath = '/wd/hub', ssl} = data;
   try {
-    const res = await request(`http${ssl ? 's' : ''}://${host}:${port}${path ? path : '/wd/hub'}/sessions`);
+    const res = await request(`http${ssl ? 's' : ''}://${host}:${port}${appiumPath}/sessions`);
     evt.sender.send('appium-client-get-sessions-response', {res});
   } catch (e) {
     evt.sender.send('appium-client-get-sessions-fail');

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -321,9 +321,9 @@ function connectClientMethodListener () {
 }
 
 const getCurrentSessions = _.debounce(async (evt, data) => {
-  const {host, port, ssl} = data;
+  const {host, port, path, ssl} = data;
   try {
-    const res = await request(`http${ssl ? 's' : ''}://${host}:${port}/wd/hub/sessions`);
+    const res = await request(`http${ssl ? 's' : ''}://${host}:${port}${path ? path : '/wd/hub'}/sessions`);
     evt.sender.send('appium-client-get-sessions-response', {res});
   } catch (e) {
     evt.sender.send('appium-client-get-sessions-fail');

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -552,14 +552,14 @@ export function setSavedServerParams () {
 
 export function getRunningSessions () {
   return (dispatch, getState) => {
-    const avoidGetRunningSessions = ['sauce', 'testobject'];
+    const avoidServerTypes = ['sauce', 'testobject'];
     // Get currently running sessions for this server
     const state = getState().session;
     const {server, serverType} = state;
     const serverInfo = server[serverType];
 
     dispatch({type: GET_SESSIONS_REQUESTED});
-    if (avoidGetRunningSessions.includes(serverType)) {
+    if (avoidServerTypes.includes(serverType)) {
       dispatch({type: GET_SESSIONS_DONE});
     } else {
       ipcRenderer.send('appium-client-get-sessions', {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -214,10 +214,10 @@ export function newSession (caps, attachSessId = null) {
         break;
       case ServerTypes.headspin: {
         const headspinUrl = url.parse(session.server.headspin.webDriverUrl);
-        host = headspinUrl.hostname;
-        port = headspinUrl.port;
-        path = headspinUrl.pathname;
-        https = headspinUrl.protocol === 'https:';
+        host = session.server.headspin.hostname = headspinUrl.hostname;
+        port = session.server.headspin.port = headspinUrl.port;
+        path = session.server.headspin.path = headspinUrl.pathname;
+        https = session.server.headspin.ssl = headspinUrl.protocol === 'https:';
         break;
       }
       case ServerTypes.perfecto:
@@ -552,14 +552,19 @@ export function setSavedServerParams () {
 
 export function getRunningSessions () {
   return (dispatch, getState) => {
+    const avoidGetRunningSessions = ['sauce', 'testobject'];
     // Get currently running sessions for this server
     const state = getState().session;
     const {server, serverType} = state;
     const serverInfo = server[serverType];
 
     dispatch({type: GET_SESSIONS_REQUESTED});
-    if (serverType !== 'sauce' && serverType !== 'testobject') {
-      ipcRenderer.send('appium-client-get-sessions', {host: serverInfo.hostname, port: serverInfo.port});
+    if (avoidGetRunningSessions.includes(serverType)) {
+      dispatch({type: GET_SESSIONS_DONE});
+    } else {
+      ipcRenderer.send('appium-client-get-sessions', {
+        host: serverInfo.hostname, port: serverInfo.port, path: serverInfo.path, ssl: serverInfo.ssl
+      });
       ipcRenderer.once('appium-client-get-sessions-response', (evt, e) => {
         const res = JSON.parse(e.res);
         dispatch({type: GET_SESSIONS_DONE, sessions: res.value});
@@ -569,8 +574,6 @@ export function getRunningSessions () {
         dispatch({type: GET_SESSIONS_DONE});
         removeRunningSessionsListeners();
       });
-    } else {
-      dispatch({type: GET_SESSIONS_DONE});
     }
   };
 }


### PR DESCRIPTION
Currently, `getRunningSessions` sends requests to `/wd/hub`.
Custom server tab and other services also can configure their own path instead of `/wd/hub`.
But then, this feature never listens to the paths.

![image](https://user-images.githubusercontent.com/5511591/57468534-970c5a80-72bf-11e9-93b1-ab967ce554a8.png)

In this PR, I changed to pass `path` and `ssl` preference to the request.
(And I understood `session.server.${serverType}.hostname` etc are used then..)


Can you review this? I wondered if this implementation had intentions.
@jlipps @dpgraham 