### PR TITLE
Fix build by updating i18next to 17.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3992,7 +3992,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -4694,8 +4693,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4716,14 +4714,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4738,20 +4734,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4868,8 +4861,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4881,7 +4873,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4896,7 +4887,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -4904,14 +4894,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4930,7 +4918,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5011,8 +4998,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5024,7 +5010,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5110,8 +5095,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5147,7 +5131,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5167,7 +5150,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5211,14 +5193,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -10111,8 +10091,7 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.0",
@@ -10385,9 +10364,9 @@
       }
     },
     "i18next": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-17.0.0.tgz",
-      "integrity": "sha512-Qnkaq9MZl+xKuCjyqD2qN+Pz4sLe2PqGrPsCi2qLFXAiDyq0xntK1e2JhKSR9RXqU/dlD3bEs86S56adj8AyzA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-17.0.3.tgz",
+      "integrity": "sha512-vQyW6a4ZLt3Dxnd6GXSnhbW5DwGYC4uLPKk1MFE5pfFbR9CEiNatdwwUZDQfrcNOh2x0eOGDFYeCEyLlkLvDQA==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "format-json": "1.x",
     "highlight.js": "9.x",
     "history": "^4.7.2",
-    "i18next": "^17.0.0",
+    "i18next": "^17.0.3",
     "i18next-node-fs-backend": "^2.1.1",
     "lodash": "4.x",
     "moment": "^2.20.1",


### PR DESCRIPTION
When I tried `npm run dev`, I faced following error:

```
[0] App threw an error during load
[0] TypeError: Cannot set property 'default' of undefined
[0]     at Object.<anonymous> (/Users/rhysd/Develop/github.com/appium/appium-desktop/node_modules/i18next/index.js:5:24)
[0]     at Object.<anonymous> (/Users/rhysd/Develop/github.com/appium/appium-desktop/node_modules/i18next/index.js:7:3)
[0]     at Module._compile (internal/modules/cjs/loader.js:711:30)
[0]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:722:10)
[0]     at Module.load (internal/modules/cjs/loader.js:620:32)
[0]     at tryModuleLoad (internal/modules/cjs/loader.js:559:12)
[0]     at Function.Module._load (internal/modules/cjs/loader.js:551:3)
[0]     at Module.require (internal/modules/cjs/loader.js:658:17)
[0]     at require (internal/modules/cjs/helpers.js:20:18)
[0]     at f (/Users/rhysd/Develop/github.com/appium/appium-desktop/dist/main.js:1:448)
```

It seemed that i18next v17.0.0 was broken.
I confirmed v17.0.3 did not raise this error so I updated the version to 17.0.3.