### PR TITLE
Push Crowdin changes directly to master

### DIFF
--- a/ci-jobs/package.yml
+++ b/ci-jobs/package.yml
@@ -13,11 +13,5 @@ jobs:
     name: 'windows_package'
 - template: templates/package.yml
   parameters:
-    target: NSIS
-    pool: 'Hosted Windows 2019 with VS2019'
-    name: 'windows_package_nsis'
-    buildScript: 'npx build --win nsis-web --publish always'
-- template: templates/package.yml
-  parameters:
     pool: 'Hosted Ubuntu 1604'
     name: 'linux_package'

--- a/ci-jobs/weekly.yml
+++ b/ci-jobs/weekly.yml
@@ -1,8 +1,11 @@
 jobs:
   - job: CrowdinSync
+    pool: 
+      vmImage: "macOS 10.13"
     steps:
     - script: |
         git remote add triager https://triager:$GITHUB_TOKEN@github.com/appium/appium-desktop
+        git checkout -b master
         git status
       env:
         GITHUB_TOKEN: $(GITHUB_TOKEN)
@@ -18,7 +21,6 @@ jobs:
         CROWDIN_PROJECT_KEY: $(CROWDIN_PROJECT_KEY)
     - script: |
         git commit -a -n -m 'Update translations'
-        git push -u triager master
+        git push -u triager crowdin-sync-$(Build.BuildNumber)
         git status
       displayName: Commit Translation Changes
-    - script: 

--- a/ci-jobs/weekly.yml
+++ b/ci-jobs/weekly.yml
@@ -5,7 +5,6 @@ jobs:
     steps:
     - script: |
         git remote add triager https://triager:$GITHUB_TOKEN@github.com/appium/appium-desktop
-        git checkout -b crowdin-sync-$(Build.BuildNumber)
         git status
       env:
         GITHUB_TOKEN: $(GITHUB_TOKEN)
@@ -20,13 +19,8 @@ jobs:
       env:
         CROWDIN_PROJECT_KEY: $(CROWDIN_PROJECT_KEY)
     - script: |
-        git commit -a -n -m 'Update translations'
-        git push -u triager crowdin-sync-$(Build.BuildNumber)
+        git commit -u triager -a -n -m 'Update translations'
+        git push -u triager master
         git status
       displayName: Commit Translation Changes
-    - script: brew install hub
-      displayName: Install Hub
-    - script: hub pull-request -m 'Update Crowdin translations'
-      displayName: Make Pull Request to Update Translations
-      env:
-        GITHUB_TOKEN: $(GITHUB_TOKEN)
+    - script: 

--- a/ci-jobs/weekly.yml
+++ b/ci-jobs/weekly.yml
@@ -1,7 +1,5 @@
 jobs:
   - job: CrowdinSync
-    pool: 
-      vmImage: "macOS 10.13"
     steps:
     - script: |
         git remote add triager https://triager:$GITHUB_TOKEN@github.com/appium/appium-desktop
@@ -19,7 +17,7 @@ jobs:
       env:
         CROWDIN_PROJECT_KEY: $(CROWDIN_PROJECT_KEY)
     - script: |
-        git commit -u triager -a -n -m 'Update translations'
+        git commit -a -n -m 'Update translations'
         git push -u triager master
         git status
       displayName: Commit Translation Changes


### PR DESCRIPTION
The weekly pipeline that updates the crowdin translations and the package-lock.json has been routinely approved and merged for months now. I think it's safe to just push directly to master and skip the pull requests.