### PR TITLE
fix: Prevent wd from injecting default desired capabilities

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -209,6 +209,12 @@ function connectCreateNewSession () {
         desiredCapabilities.connectHardwareKeyboard = true;
       }
 
+      // Prevent wd from injecting default desired capabilities
+      if (typeof desiredCapabilities.wdNoDefaults === 'undefined' &&
+          typeof desiredCapabilities['wd-no-defaults'] === 'undefined') {
+        desiredCapabilities.wdNoDefaults = true;
+      }
+
       // Try initializing it. If it fails, kill it and send error message to sender
       let p = driver.init(desiredCapabilities);
       event.sender.send('appium-new-session-successful');


### PR DESCRIPTION
If the capability `deviceName` is not defined (for example if it is defined by appium server's default capabilities), this PR will prevent  `wd` from injecting `"browserName": "firefox"`.

See https://github.com/admc/wd/blob/13ffe77a1a599dcff5dcb8242c003e14cfcab57d/lib/webdriver.js#L83-L91

Fixes #667