### PR TITLE
fix: Update spelling of suppressed

### DIFF
--- a/app/renderer/components/StartServer/AdvancedTab.js
+++ b/app/renderer/components/StartServer/AdvancedTab.js
@@ -145,7 +145,7 @@ class AdvancedTab extends Component {
               {this.buildInput('localTimezone', 'checkbox', t('Local Timezone'))}
               {this.buildInput('sessionOverride', 'checkbox', t('Allow Session Override'))}
               {this.buildInput('logTimestamp', 'checkbox', t('Log Timestamps'))}
-              {this.buildInput('logNoColors', 'checkbox', t('Supress Log Color'))}
+              {this.buildInput('logNoColors', 'checkbox', t('Suppress Log Color'))}
               {this.buildInput('enforceStrictCaps', 'checkbox', t('Strict Caps Mode'))}
               {this.buildInput('relaxedSecurityEnabled', 'checkbox', t('Relaxed Security'))}
               {this.buildInput('defaultCapabilities', 'textarea', t('Default Capabilities'))}

--- a/assets/locales/de/translation.json
+++ b/assets/locales/de/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Lokale Zeitzone",
   "Allow Session Override": "Sessionüberschreibung erlauben",
   "Log Timestamps": "Protokoll-Zeitmarken",
-  "Supress Log Color": "Protokollfarbe deaktivieren",
+  "Suppress Log Color": "Protokollfarbe deaktivieren",
   "Strict Caps Mode": "Beschränkter Fähigkeitenmodus",
   "Relaxed Security": "Entspannte Sicherheit",
   "Default Capabilities": "Standardfähigkeiten",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Local Timezone",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/es-ES/translation.json
+++ b/assets/locales/es-ES/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Zona horaria local",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Remover colores de registro",
+  "Suppress Log Color": "Remover colores de registro",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/fa/translation.json
+++ b/assets/locales/fa/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "زمان در منطقه جقرافیایی",
   "Allow Session Override": "اجازه جایگزینی جلسه",
   "Log Timestamps": "گزارش Timestamp",
-  "Supress Log Color": "از بین بردن رنگ در گزارش",
+  "Suppress Log Color": "از بین بردن رنگ در گزارش",
   "Strict Caps Mode": "حالت سختگیری برای قابلیت ها (Caps) ",
   "Relaxed Security": "شل گرفتن امنیت",
   "Default Capabilities": "قابلیت های پیش فرض",

--- a/assets/locales/fr/translation.json
+++ b/assets/locales/fr/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Fuseau horaire local",
   "Allow Session Override": "Autoriser la surcharge de session",
   "Log Timestamps": "Afficher l'horodatage",
-  "Supress Log Color": "Supprimer la colorisation des logs",
+  "Suppress Log Color": "Supprimer la colorisation des logs",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/hi/translation.json
+++ b/assets/locales/hi/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "स्थानीय समय क्षेत्र",
   "Allow Session Override": "सत्र ओवरराइड की अनुमति दें",
   "Log Timestamps": "लॉग टाइमस्टैम्प",
-  "Supress Log Color": "लॉग कलर को रोके",
+  "Suppress Log Color": "लॉग कलर को रोके",
   "Strict Caps Mode": "सख्त कैप्स मोड",
   "Relaxed Security": "सुरक्षा में ढील दी गई",
   "Default Capabilities": "पूर्वचयनित क्षमताये",

--- a/assets/locales/it/translation.json
+++ b/assets/locales/it/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Local Timezone",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/ja/translation.json
+++ b/assets/locales/ja/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "ローカルタイムゾーンを使う",
   "Allow Session Override": "セッションの上書きを許可",
   "Log Timestamps": "ログにタイムスタンプを付与する",
-  "Supress Log Color": "ログに色を付けない",
+  "Suppress Log Color": "ログに色を付けない",
   "Strict Caps Mode": "Appiumの設定を厳密にする",
   "Relaxed Security": "セキュリティ設定を緩和する",
   "Default Capabilities": "Appiumの既定設定",

--- a/assets/locales/kn/translation.json
+++ b/assets/locales/kn/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "ಸ್ಥಳೀಯ ಕಾಲವಲಯ",
   "Allow Session Override": "ಸೆಷನ್ ಓವರ್ ರೈಡ್ಗೆ ಅನುಮತಿ ಮಾಡಿ",
   "Log Timestamps": "ಲಾಗ್ ಟೈಮ್ ಸ್ಟ್ಯಾಂಪ್ಸ್",
-  "Supress Log Color": "ಸಪ್ರೆಸ್ಸ್ ಲಾಗ್ ಕಲರ್",
+  "Suppress Log Color": "ಸಪ್ರೆಸ್ಸ್ ಲಾಗ್ ಕಲರ್",
   "Strict Caps Mode": "ಸ್ಟ್ರಿಕ್ಟ್ ಕ್ಯಾಪ್ಸ್ ಮೋಡ್",
   "Relaxed Security": "ಸಡಿಲಗೊಳಿಸಿದ ಭದ್ರತೆ",
   "Default Capabilities": "ಅನುಪಸ್ಥಿತಿಯಲ್ಲಿನ ಕ್ಯಾಪಬಿಲಿಟಿಸ್",

--- a/assets/locales/ko/translation.json
+++ b/assets/locales/ko/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "현지 시간대",
   "Allow Session Override": "세션 재정의 허용",
   "Log Timestamps": "로그 타임스탬프",
-  "Supress Log Color": "로그 색상무시",
+  "Suppress Log Color": "로그 색상무시",
   "Strict Caps Mode": "엄격 Caps 모드",
   "Relaxed Security": "느슨한 보안",
   "Default Capabilities": "기본 Capabilities",

--- a/assets/locales/ml-IN/translation.json
+++ b/assets/locales/ml-IN/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Local Timezone",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/pa-IN/translation.json
+++ b/assets/locales/pa-IN/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Local Timezone",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/pt-BR/translation.json
+++ b/assets/locales/pt-BR/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Local Timezone",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/pt-PT/translation.json
+++ b/assets/locales/pt-PT/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Local Timezone",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/ru/translation.json
+++ b/assets/locales/ru/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "Местный часовой пояс",
   "Allow Session Override": "Разрешить переопределение сессии",
   "Log Timestamps": "Записывать метки времени в журнал",
-  "Supress Log Color": "Текст журнала одним цветом",
+  "Suppress Log Color": "Текст журнала одним цветом",
   "Strict Caps Mode": "Строгий режим для возможностей устройств",
   "Relaxed Security": "Без дополнительной защиты",
   "Default Capabilities": "Возможности по умолчанию",

--- a/assets/locales/te/translation.json
+++ b/assets/locales/te/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "స్థానిక టైం జోన్",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",

--- a/assets/locales/zh-CN/translation.json
+++ b/assets/locales/zh-CN/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "本地时区",
   "Allow Session Override": "允许会话覆盖",
   "Log Timestamps": "记录时间戳",
-  "Supress Log Color": "禁用协议颜色",
+  "Suppress Log Color": "禁用协议颜色",
   "Strict Caps Mode": "严格限制模式",
   "Relaxed Security": "放松安全性",
   "Default Capabilities": "默认能力",

--- a/assets/locales/zh-TW/translation.json
+++ b/assets/locales/zh-TW/translation.json
@@ -58,7 +58,7 @@
   "Local Timezone": "本地時區",
   "Allow Session Override": "Allow Session Override",
   "Log Timestamps": "Log Timestamps",
-  "Supress Log Color": "Supress Log Color",
+  "Suppress Log Color": "Suppress Log Color",
   "Strict Caps Mode": "Strict Caps Mode",
   "Relaxed Security": "Relaxed Security",
   "Default Capabilities": "Default Capabilities",


### PR DESCRIPTION
Previously wrongly spelt as supressed

Fixes #1060 