### PR TITLE
feat: Remove testingbot from avoidServerTypes in getRunningSessions

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -553,7 +553,7 @@ export function setSavedServerParams () {
 export function getRunningSessions () {
   return (dispatch, getState) => {
     const avoidServerTypes = [
-      'sauce', 'testobject', 'testingbot'
+      'sauce', 'testobject'
     ];
     // Get currently running sessions for this server
     const state = getState().session;


### PR DESCRIPTION
Hi,

We've made sure that `getRunningSessions` will work, please remove testingbot from the avoidServerTypes.

Thanks