### PR TITLE
chore: add electron-builder to avoid no build command error

### DIFF
--- a/ci-jobs/templates/package.yml
+++ b/ci-jobs/templates/package.yml
@@ -7,7 +7,7 @@ parameters:
   pool: ''
   xvfb: false
   target: ''
-  buildScript: 'npx build --publish always'
+  buildScript: 'npx electron-builder build --publish always'
 jobs:
   - job: ${{parameters.name}}
     pool: ${{parameters.pool}}


### PR DESCRIPTION
Not sure this need on CI, too, but I got 'command not found: build' error when I ran 'npx build --publish never'  in another package. Then, I also tried this repository and got the same error.

If 'npx build' does work on CI, this PR will need, I assume.