### PR TITLE
[WIP] feat: add viewtag as search locator strategy

### DIFF
--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -41,6 +41,7 @@ class ElementLocator extends Component {
       ['accessibility id', 'Accessibility ID'],
       ['-android uiautomator', 'UIAutomator Selector (Android UiAutomator2)'],
       ['-android datamatcher', 'DataMatcher Selector (Android Espresso)'],
+      ['-android viewtag', 'Android View Tag (Android Espresso)'],
       ['-ios predicate string', 'Predicate String (iOS)'],
       ['-ios class chain', 'Class Chain (iOS)'],
     ];

--- a/app/renderer/lib/client-frameworks/java.js
+++ b/app/renderer/lib/client-frameworks/java.js
@@ -68,6 +68,7 @@ ${this.indent(code, 4)}
       'name': 'Name',
       '-android uiautomator': 'AndroidUIAutomator',
       '-android datamatcher': 'AndroidDataMatcher',
+      '-android viewtag': 'AndroidViewTag',
       '-ios predicate string': 'IosNsPredicate',
       '-ios class chain': 'IosClassChain',
     };

--- a/app/renderer/lib/client-frameworks/js-wd.js
+++ b/app/renderer/lib/client-frameworks/js-wd.js
@@ -35,6 +35,7 @@ main().catch(console.log);
       'class name': 'ClassName',
       '-android uiautomator': 'AndroidUIAutomator',
       '-android datamatcher': 'AndroidDataMatcher',
+      '-android viewtag': 'unsupported',
       '-ios predicate string': 'IosUIAutomation',
       '-ios class chain': 'IosClassChain',
     };

--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -49,6 +49,7 @@ ${this.indent(this.chainifyCode(code), 2)}
       case 'class name': locator = `${locator}`; break;
       case '-android uiautomator': locator = `android=${locator}`; break;
       case '-android datamatcher': locator = `android=${locator}`; break;
+      case '-android viewtag': locator = `android=unsupported`; break;
       case '-ios predicate string': locator = `ios=${locator}`; break;
       case '-ios class chain': locator = `ios=${locator}`; break; // TODO: Handle IOS class chain properly. Not all libs support it. Or take it out
       default: throw new Error(`Can't handle strategy ${strategy}`);

--- a/app/renderer/lib/client-frameworks/python.js
+++ b/app/renderer/lib/client-frameworks/python.js
@@ -41,6 +41,7 @@ driver.quit()`;
       'class name': 'class_name',
       '-android uiautomator': 'android_uiautomator',
       '-android datamatcher': 'android_datamatcher',
+      '-android viewtag': 'android_viewtag',
       '-ios predicate string': 'ios_predicate',
       '-ios class chain': 'ios_uiautomation', // TODO: Could not find iOS UIAutomation
     };

--- a/app/renderer/lib/client-frameworks/robot.js
+++ b/app/renderer/lib/client-frameworks/robot.js
@@ -57,6 +57,7 @@ ${this.indent(code, 4)}
       'class name': 'class_name',
       '-android uiautomator': 'unsupported',
       '-android datamatcher': 'unsupported',
+      '-android viewtag': 'unsupported',
       '-ios predicate string': 'ios_predicate',
       '-ios class chain': 'ios_uiautomation', // TODO: Could not find iOS UIAutomation
     };

--- a/app/renderer/lib/client-frameworks/ruby.js
+++ b/app/renderer/lib/client-frameworks/ruby.js
@@ -39,6 +39,7 @@ driver.quit`;
       'class name': ':class_name',
       '-android uiautomator': ':uiautomation',
       '-android datamatcher': ':datamatcher',
+      '-android viewtag': ':viewtag',
       '-ios predicate string': ':predicate',
       '-ios class chain': ':class_chain',
     };


### PR DESCRIPTION
- Add Android viewtag (Espresso Only) as search locator strategy 



Edit: just found out how u guys implement script recording, currently, it will crash if we use viewtag for script recording

i'll take a look at supported library and how they use viewtag as locator strategy

_TODO:_
- [x] Js-wd [unsupported](https://github.com/admc/wd/blob/13ffe77a1a599dcff5dcb8242c003e14cfcab57d/lib/utils.js#L47)
- [x] Js-wdio [unsupported](https://github.com/webdriverio/webdriverio/blob/e79328564e049fe6c81f0319ffe89d9293462e69/packages/webdriverio/src/utils/findStrategy.js)
- [x] Java - [AndroidViewTag](https://github.com/appium/java-client/blob/5d76ed5c5ce5ebc6ddcb36dc3e83fb12e11b17db/src/main/java/io/appium/java_client/FindsByAndroidViewTag.java)
- [x] Python - [android_viewtag](https://github.com/appium/python-client/blob/13240d7d9f41677b9798c4fb54ee2a2cc58fd24f/appium/webdriver/webdriver.py#L440)
- [x] Ruby [:viewtag](https://github.com/appium/ruby_lib_core/blob/67df100c694e1a3d05abba2018d8243b94ba5f9e/lib/appium_lib_core/common/base/search_context.rb#L28)
- [x] Robot Framework [unsupported](https://github.com/serhatbolsu/robotframework-appiumlibrary/blob/d7b09bcdfff212cfa0cbf2902b27c4a42485a500/AppiumLibrary/locators/elementfinder.py)