### PR TITLE
fix: shows newer version available dialog only when the local version is lower than it

### DIFF
--- a/app/main/auto-updater/update-checker.js
+++ b/app/main/auto-updater/update-checker.js
@@ -1,10 +1,11 @@
 import request from 'request-promise';
 import { getFeedUrl } from './config';
+import semver from 'semver';
 
 export async function checkUpdate (currentVersion) {
   try {
     const res = await request.get(getFeedUrl(currentVersion));
-    if (res) {
+    if (res && semver.lt(currentVersion, res.name)) {
       return JSON.parse(res);
     }
   } catch (ign) { }

--- a/app/main/auto-updater/update-checker.js
+++ b/app/main/auto-updater/update-checker.js
@@ -4,6 +4,11 @@ import semver from 'semver';
 
 export async function checkUpdate (currentVersion) {
   try {
+    // The response is like (macOS):
+    // {  "name":"v1.15.0-1",
+    //    "notes":"* Bump up Appium to v1.15.0",
+    //    "pub_date":"2019-10-04T04:40:37Z",
+    //    "url":"https://github.com/appium/appium-desktop/releases/download/v1.15.0-1/Appium-1.15.0-1-mac.zip"}
     const res = await request.get(getFeedUrl(currentVersion));
     if (res) {
       const j = JSON.parse(res);

--- a/app/main/auto-updater/update-checker.js
+++ b/app/main/auto-updater/update-checker.js
@@ -5,8 +5,11 @@ import semver from 'semver';
 export async function checkUpdate (currentVersion) {
   try {
     const res = await request.get(getFeedUrl(currentVersion));
-    if (res && semver.lt(currentVersion, res.name)) {
-      return JSON.parse(res);
+    if (res) {
+      const j = JSON.parse(res);
+      if (semver.lt(currentVersion, j.name)) {
+        return j;
+      }
     }
   } catch (ign) { }
 


### PR DESCRIPTION
`res` gets value if the latest release tagged version on github is not the current local app version.
Thus, update dialog appears when a user has a newer pre-released version than the latest release tagged version on github.

e.g.
A user has 1.15.0 on their local, but this repository's release tagged version is 1.14.0
=> Then, the local version shows update dialog to 1.14.0

We can see questions about this issue on this repository. So, I've added version comparison after getting the `res`. So, if the local version is greater than the github one, no available device dialog appears.