### PR TITLE
fix: menu items for non-mac

### DIFF
--- a/app/main/menus.js
+++ b/app/main/menus.js
@@ -233,13 +233,13 @@ function otherMenuFile () {
 
 function otherMenuView () {
   const submenu = [];
-  submenu.push([{
+  submenu.push({
     label: i18n.t('Toggle &Full Screen'),
     accelerator: 'F11',
     click () {
       mainWindow.setFullScreen(!mainWindow.isFullScreen());
     }
-  }]);
+  });
 
   submenu.push({
     label: i18n.t('Languages'),


### PR DESCRIPTION
closes https://github.com/appium/appium-desktop/issues/1037

I found a redundant bracket. It fixes the issue. I checked on windows env.