### PR TITLE
fix: use electron-updater instead of built-in autoUpdater

### DIFF
--- a/app/main/auto-updater/index.js
+++ b/app/main/auto-updater/index.js
@@ -4,11 +4,11 @@
  * Similar to https://electronjs.org/docs/api/auto-updater#events
  * See https://electronjs.org/docs/tutorial/updates for documentation
  */
-import { app, autoUpdater, dialog } from 'electron';
+import { app, dialog } from 'electron';
+import { autoUpdater } from 'electron-updater';
 import moment from 'moment';
 import B from 'bluebird';
 import { checkUpdate } from './update-checker';
-import { getFeedUrl } from './config';
 import _ from 'lodash';
 import env from '../../env';
 import i18n from '../../configs/i18next.config';
@@ -19,9 +19,6 @@ const runningLocally = isDev || process.env.RUNNING_LOCALLY;
 let checkNewUpdates = _.noop;
 
 if (!runningLocally && !process.env.RUNNING_IN_SPECTRON) {
-
-  autoUpdater.setFeedURL(getFeedUrl(app.getVersion()));
-
   /**
    * Check for new updates
    */


### PR DESCRIPTION
When I investigated https://github.com/appium/appium-desktop/issues/1042, I found https://www.electron.build/auto-update#event-checking-for-update recommended to use `autoUpdater` in `electron-updater`.

Then, we no longer need `setFeedURL`

> Do not call setFeedURL. electron-builder automatically creates app-update.yml file for you on build in the resources (this file is internal, you don’t need to be aware of it).

I checked `app-update.yml` existed expectedly as the same body.
```
$ cat app-update.yml 
owner: appium
repo: appium-desktop
provider: github
vPrefixedTagName: true
updaterCacheDirName: appium-desktop-updater
```

This change does not fix "Could not find squirrel" error, but let me follow the recommended way.
I tested to download a newer version on my env (mac and windows).