### PR TITLE
fix: break word in selected element

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -199,7 +199,6 @@
     word-break: break-all;
  }
 
-
 .selected-element-card {
     display: flex;
     flex-direction: column;

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -194,6 +194,12 @@
     margin-bottom: 20px;
 }
 
+.selected-element-table-cells {
+    word-wrap: break-all;
+    word-break: break-all;
+ }
+
+
 .selected-element-card {
     display: flex;
     flex-direction: column;
@@ -340,7 +346,7 @@
  .actions-container :global(.ant-select) {
     width: 100%;
  }
- 
+
  .actions-container :global(.ant-btn) {
     width: 100%;
  }

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -8,8 +8,6 @@ import { clipboard } from 'electron';
 
 const ButtonGroup = Button.Group;
 
-const tableColumnsStyle = { wordWrap: 'break-all', wordBreak: 'break-all' };
-
 /**
  * Shows details of the currently selected element and shows methods that can
  * be called on the elements (tap, sendKeys)
@@ -49,14 +47,13 @@ class SelectedElement extends Component {
       dataIndex: 'name',
       key: 'name',
       width: 100,
-      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
+      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
 
     }, {
       title: t('Value'),
       dataIndex: 'value',
       key: 'value',
-      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
-
+      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
     }];
 
     // Get the data for the attributes table
@@ -74,12 +71,12 @@ class SelectedElement extends Component {
       dataIndex: 'find',
       key: 'find',
       width: 100,
-      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
+      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
     }, {
       title: t('Selector'),
       dataIndex: 'selector',
       key: 'selector',
-      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
+      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
     }];
 
     // Get the data for the strategies table

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -8,6 +8,8 @@ import { clipboard } from 'electron';
 
 const ButtonGroup = Button.Group;
 
+const tableColumnsStyle = { wordWrap: 'break-word', wordBreak: 'break-word' };
+
 /**
  * Shows details of the currently selected element and shows methods that can
  * be called on the elements (tap, sendKeys)
@@ -46,11 +48,15 @@ class SelectedElement extends Component {
       title: t('Attribute'),
       dataIndex: 'name',
       key: 'name',
-      width: 100
+      width: 100,
+      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
+
     }, {
       title: t('Value'),
       dataIndex: 'value',
-      key: 'value'
+      key: 'value',
+      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
+
     }];
 
     // Get the data for the attributes table
@@ -67,11 +73,13 @@ class SelectedElement extends Component {
       title: t('Find By'),
       dataIndex: 'find',
       key: 'find',
-      width: 100
+      width: 100,
+      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
     }, {
       title: t('Selector'),
       dataIndex: 'selector',
-      key: 'selector'
+      key: 'selector',
+      render: (text) => (<div style={tableColumnsStyle}>{text}</div>)
     }];
 
     // Get the data for the strategies table
@@ -137,12 +145,14 @@ class SelectedElement extends Component {
         </Col>
       </Row>
       {findDataSource.length > 0 &&
-        <Table
-          columns={findColumns}
-          dataSource={findDataSource}
-          size="small"
-          pagination={false}
-        />}
+        <Row>
+          <Table
+            columns={findColumns}
+            dataSource={findDataSource}
+            size="small"
+            pagination={false} />
+        </Row>
+      }
       <br />
       {showXpathWarning &&
         <div>
@@ -155,9 +165,13 @@ class SelectedElement extends Component {
         </div>
       }
       {dataSource.length > 0 &&
-      <Row>
-        <Table columns={attributeColumns} dataSource={dataSource} size="small" pagination={false} />
-      </Row>
+        <Row>
+          <Table
+            columns={attributeColumns}
+            dataSource={dataSource}
+            size="small"
+            pagination={false} />
+        </Row>
       }
       <Modal title={t('Send Keys')}
         visible={sendKeysModalVisible}

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -8,6 +8,9 @@ import { clipboard } from 'electron';
 
 const ButtonGroup = Button.Group;
 
+const selectedElementTableCell = (text) => (
+  <div className={styles['selected-element-table-cells']}>{text}</div>)
+
 /**
  * Shows details of the currently selected element and shows methods that can
  * be called on the elements (tap, sendKeys)
@@ -47,13 +50,13 @@ class SelectedElement extends Component {
       dataIndex: 'name',
       key: 'name',
       width: 100,
-      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
+      render: selectedElementTableCell
 
     }, {
       title: t('Value'),
       dataIndex: 'value',
       key: 'value',
-      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
+      render: selectedElementTableCell
     }];
 
     // Get the data for the attributes table
@@ -71,12 +74,12 @@ class SelectedElement extends Component {
       dataIndex: 'find',
       key: 'find',
       width: 100,
-      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
+      render: selectedElementTableCell
     }, {
       title: t('Selector'),
       dataIndex: 'selector',
       key: 'selector',
-      render: (text) => (<div className={styles['selected-element-table-cells']}>{text}</div>)
+      render: selectedElementTableCell
     }];
 
     // Get the data for the strategies table

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -8,7 +8,7 @@ import { clipboard } from 'electron';
 
 const ButtonGroup = Button.Group;
 
-const tableColumnsStyle = { wordWrap: 'break-word', wordBreak: 'break-word' };
+const tableColumnsStyle = { wordWrap: 'break-all', wordBreak: 'break-all' };
 
 /**
  * Shows details of the currently selected element and shows methods that can

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -9,7 +9,7 @@ import { clipboard } from 'electron';
 const ButtonGroup = Button.Group;
 
 const selectedElementTableCell = (text) => (
-  <div className={styles['selected-element-table-cells']}>{text}</div>)
+  <div className={styles['selected-element-table-cells']}>{text}</div>);
 
 /**
  * Shows details of the currently selected element and shows methods that can


### PR DESCRIPTION
- before
<img src="https://user-images.githubusercontent.com/5511591/68538034-5c3fc800-03b1-11ea-9b65-c646751d39ec.png" width="300">

- after
<img src="https://user-images.githubusercontent.com/5511591/68538157-5e0a8b00-03b3-11ea-874f-d5912a8e5761.png" width=300>



----

closes https://github.com/appium/appium-desktop/issues/957 

This trick was linked in https://ant.design/components/table/