### PR TITLE
fix: add scroll in saved capability sets

### DIFF
--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -5,7 +5,7 @@ import { Button, Row, Col, Table } from 'antd';
 import FormattedCaps from './FormattedCaps';
 import SessionCSS from './Session.css';
 
-const heightOfServerConfigArea = 400;
+const HEIGHT_OF_SERVICE_CONFIG_AREA = 400;
 
 export default class SavedSessions extends Component {
 
@@ -83,7 +83,7 @@ export default class SavedSessions extends Component {
       });
     }
 
-    const windowSizeHeight = remote.getCurrentWindow().getSize()[1] - heightOfServerConfigArea;
+    const windowSizeHeight = remote.getCurrentWindow().getSize()[1] - HEIGHT_OF_SERVICE_CONFIG_AREA;
     return (<Row gutter={20} className={SessionCSS['saved-sessions']}>
       <Col span={12}>
         <Table

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import moment from 'moment';
+import { remote } from 'electron';
 import { Button, Row, Col, Table } from 'antd';
 import FormattedCaps from './FormattedCaps';
 import SessionCSS from './Session.css';
 
+const heightOfServerConfigArea = 400;
 
 export default class SavedSessions extends Component {
-
 
   constructor (props) {
     super(props);
@@ -82,10 +83,12 @@ export default class SavedSessions extends Component {
       });
     }
 
-
+    const windowSizeHeight = remote.getCurrentWindow().getSize()[1] - heightOfServerConfigArea;
     return (<Row gutter={20} className={SessionCSS['saved-sessions']}>
       <Col span={12}>
-        <Table pagination={false}
+        <Table
+          scroll={{ y: windowSizeHeight }}
+          pagination={false}
           dataSource={dataSource}
           columns={columns}
           onRowClick={this.onRowClick}


### PR DESCRIPTION
- before: We cannot get items in a hidden area. The below image had 11 items, but we can select 3 of 11. They appear after resizing the size of the window.

![image](https://user-images.githubusercontent.com/5511591/68541328-6bd70500-03e1-11ea-97b4-62a9c633a6eb.png)


- after:

![image](https://user-images.githubusercontent.com/5511591/68541331-709bb900-03e1-11ea-9035-055c19001d97.png)

We should calculate the available area dynamically 