### PR TITLE
feat: update electron version to v6

### DIFF
--- a/app/renderer/components/Config/Config.js
+++ b/app/renderer/components/Config/Config.js
@@ -10,7 +10,7 @@ const ENV_VARIABLE_NAMES = [
 const {app, dialog, getCurrentWindow} = remote;
 
 class Config extends Component {
-  componentWillMount () {
+  componentDidMount () {
     this.props.getEnvironmentVariables();
   }
 

--- a/app/renderer/components/ServerMonitor/ServerMonitor.js
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.js
@@ -121,6 +121,7 @@ export default class ServerMonitor extends Component {
     if (n) {
       this.shouldScroll = n.scrollTop + n.offsetHeight >= n.scrollHeight;
     }
+    return null;
   }
 
   componentDidUpdate () {

--- a/app/renderer/components/ServerMonitor/ServerMonitor.js
+++ b/app/renderer/components/ServerMonitor/ServerMonitor.js
@@ -115,7 +115,7 @@ export default class ServerMonitor extends Component {
     document.removeEventListener('keydown', this.keydownListener);
   }
 
-  componentWillUpdate () {
+  getSnapshotBeforeUpdate () {
     this.shouldScroll = false;
     let n = this._term;
     if (n) {

--- a/app/renderer/components/Session/CloudProviderSelector.js
+++ b/app/renderer/components/Session/CloudProviderSelector.js
@@ -6,7 +6,7 @@ import SessionStyles from './Session.css';
 
 export default class CloudProviderSelector extends Component {
 
-  componentWillMount () {
+  componentDidMount () {
     const {setLocalServerParams, getSavedSessions, setSavedServerParams, getRunningSessions} = this.props;
     (async () => {
       await getSavedSessions();

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -18,7 +18,7 @@ const ADD_CLOUD_PROVIDER = 'addCloudProvider';
 
 export default class Session extends Component {
 
-  componentWillMount () {
+  componentDidMount () {
     const {setLocalServerParams, getSavedSessions, setSavedServerParams, setVisibleProviders, getRunningSessions} = this.props;
     (async () => {
       await getSavedSessions();

--- a/app/renderer/components/StartServer/PresetsTab.js
+++ b/app/renderer/components/StartServer/PresetsTab.js
@@ -17,7 +17,7 @@ class PresetsTab extends Component {
     this.state = {selectedPreset: null};
   }
 
-  componentWillMount () {
+  componentDidMount () {
     this.props.getPresets();
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11581,9 +11581,9 @@
       "dev": true
     },
     "electron": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.6.tgz",
-      "integrity": "sha512-0L53lv26eDhaaNxL6DqXGQrQOEAYbrQg40stRSb2pzrY06kwPbABzXEiaCvEsBuKUQ+9OQBbVyyvXRbLJlun/A==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.1.5.tgz",
+      "integrity": "sha512-PrdJKkAS0IaSJwu4him03VYqvAKK1qyWTE/ieb4LgcbR4F4u90b91/7xna6P1GpD/FXiHqzZQcs0SvK/o08ckQ==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -12009,9 +12009,9 @@
       }
     },
     "electron-chromedriver": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-5.0.1.tgz",
-      "integrity": "sha512-w82q6KkIsKjzhcucllpxeulIxYn5rccNw43rpbMuZcgMQ0EPsckoYwUt7Gadmdi14xniZ+debN9SM8V1EUyaBQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-6.0.0.tgz",
+      "integrity": "sha512-UIhRl0sN5flfUjqActXsFrZQU1NmBObvlxzPnyeud8vhR67TllXCoqfvhQJmIrJAJJK+5M1DFhJ5iTGT++dvkg==",
       "dev": true,
       "requires": {
         "electron-download": "^4.1.1",
@@ -21862,13 +21862,13 @@
       "dev": true
     },
     "spectron": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/spectron/-/spectron-7.0.0.tgz",
-      "integrity": "sha512-l6EqXNJLLjbHFr4s2tky0hQU7Ql8UzNsAJm6CiDvX1eGOPiRVJBf2lqZWHGPayZQ7auxdhqAhnHceJJkokDiPQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/spectron/-/spectron-8.0.0.tgz",
+      "integrity": "sha512-MI9+lAamDnw7S0vKaxXjU3g5qaW5KANaFLc+Hgq+QmMCkQbZLt6ukFFGfalmwIuYrmq+yWQPCD4CXgt3VSHrLA==",
       "dev": true,
       "requires": {
         "dev-null": "^0.1.1",
-        "electron-chromedriver": "^5.0.1",
+        "electron-chromedriver": "^6.0.0",
         "request": "^2.87.0",
         "split": "^1.0.0",
         "webdriverio": "^4.13.0"

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "cross-env": "^6.0.0",
     "devtron": "1.x",
     "dir-compare": "^1.4.0",
-    "electron": "^5.0.6",
+    "electron": "^6.1.5",
     "electron-builder": "^22.1.0",
     "electron-builder-lib": "^20.15.3",
     "electron-devtools-installer": "^2.2.3",
@@ -205,7 +205,7 @@
     "rimraf": "^3.0.0",
     "run-s": "0.0.0",
     "sinon": "^7.3.1",
-    "spectron": "^7.0.0",
+    "spectron": "^8.0.0",
     "xmldom": "^0.1.27"
   },
   "devEngines": {


### PR DESCRIPTION
Update electron version to v6.
v7 is available, but let me update the version one by one.

- `componentWillMount` was changed.
    - Move the logic which has fetching data into `didMount`
    ```
    /Users/kazu/GitHub/appium-desktop/node_modules/react-dom/cjs/react-dom.development.js:11494 Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

    * Move code with side effects to componentDidMount, and set initial state in the constructor.
    * Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
    ```
    - I checked each component can load data by maual
- `componentWillUpdate`
    - https://reactjs.org/docs/react-component.html#getsnapshotbeforeupdate
    - `ServerMonitor.js` will scroll down automatically if some new logs come.
        - I checked the behaviour with the current change.
        - When there was no `return null`, an error that required to return something (not undefined) happened. The return value was used in `componentDidUpdate`, but we did not use it. so, return `null` was enough to prevent the error.


