### PR TITLE
fix(shared): escape double quotes within a double quoted template query

### DIFF
--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -24,7 +24,7 @@ export function isUnique (attrName, attrValue, sourceXML) {
     return true;
   }
   const doc = new DOMParser().parseFromString(sourceXML);
-  return xpath.select(`//*[@${attrName}="${attrValue}"]`, doc).length < 2;
+  return xpath.select(`//*[@${attrName}="${attrValue.replace(/"/g, '')}"]`, doc).length < 2;
 }
 
 // Map of the optimal strategies.


### PR DESCRIPTION
# problem

appium models contain KV pairs, where the values of those pairs may contain double quote characters: `"`.

isUnique wraps a query in double quotes, thus the xpath.select(...) call cannot parse the passed query due to bad quote inputs.

# solution

- escape double quotes from the query

# discussion

partially fixes #1057.