### PR TITLE
feat: add <ErrorBoundary /> for improved error condition UX

### DIFF
--- a/app/renderer/components/ErrorBoundary/ErrorBoundary.css
+++ b/app/renderer/components/ErrorBoundary/ErrorBoundary.css
@@ -1,0 +1,3 @@
+.errorBoundary {
+  margin: 1em;
+}

--- a/app/renderer/components/ErrorBoundary/ErrorBoundary.js
+++ b/app/renderer/components/ErrorBoundary/ErrorBoundary.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Alert } from 'antd';
+import styles from './ErrorBoundary.css';
+
+const CREATE_ISSUE_URL = 'https://github.com/appium/appium-desktop/issues/new';
+
+export default class ErrorBoundary extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      error: null
+    };
+  }
+
+  static getDerivedStateFromError (error) {
+    // Update state so the next render will show the fallback UI.
+    return { error };
+  }
+
+  render () {
+    const { error } = this.state;
+    if (error) {
+      return (
+        <div className={styles.errorBoundary}>
+          <Alert
+            message="Unhandled Exception"
+            type="error"
+            description={
+              <>
+                <span children={`An unexpected error occurred with message: ${error.message}.`} />
+                <br />
+                <span children='Please kindly open up a bug report at ' />
+                <a href={CREATE_ISSUE_URL} children={CREATE_ISSUE_URL}/>.
+                <pre children={error.stack} />
+              </>
+            }
+          />
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import Root from './containers/Root';
+import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 import { AppContainer } from 'react-hot-loader';
 import Store from './store/configureStore';
 
@@ -10,7 +11,9 @@ const store = configureStore();
 
 render(
   <AppContainer>
-    <Root store={store} history={history} />
+    <ErrorBoundary>
+      <Root store={store} history={history} />
+    </ErrorBoundary>
   </AppContainer>,
   document.getElementById('root')
 );

--- a/ci-jobs/package.yml
+++ b/ci-jobs/package.yml
@@ -2,7 +2,8 @@
 jobs:
 - template: templates/package.yml
   parameters:
-    pool: 'Hosted MacOS Preview'
+    pool:
+      vmImage: 'macOS-10.14'
     name: 'osx_package'
 - template: templates/package.yml
   parameters:

--- a/ci-jobs/pr-validation.yml
+++ b/ci-jobs/pr-validation.yml
@@ -2,7 +2,8 @@
 jobs:
 - template: templates/pr-validation.yml
   parameters:
-    pool: 'Hosted MacOS Preview'
+    pool:
+      vmImage: 'macOS-10.14'
     name: 'osx_build'
     e2e: true
 - template: templates/pr-validation.yml


### PR DESCRIPTION
# problem

#1057 and other related issues suffer `Error`s being thrown, yielding an unactionable, blank screen.

# solution

improve the UX by adding an error boundary, communicating the exception to the user, and inviting her to create a new github issue.

![image](https://user-images.githubusercontent.com/1003261/72652591-3b10d000-393c-11ea-8dda-8e2935a39455.png)
 