### PR TITLE
feat: Sends W3C spec session creation request

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -215,6 +215,10 @@ function connectCreateNewSession () {
         desiredCapabilities.wdNoDefaults = true;
       }
 
+      // Allow to send W3C spec capabilities in addition to MJSONWP
+      desiredCapabilities.allowW3C = true;
+      desiredCapabilities.w3cPrefix = 'appium';
+
       // Try initializing it. If it fails, kill it and send error message to sender
       let p = driver.init(desiredCapabilities);
       event.sender.send('appium-new-session-successful');


### PR DESCRIPTION
Current session creates by AD is MJSONWP, only `desiredCapabilities`.
With this change, the request will have W3C spec, too, as below.


> [info] [35m[HTTP][39m [90m{"capabilities":{"alwaysMatch":{"appium:autoAcceptsAlerts":"true","appium:automationName":"xcuitest","browserName":"safari","appium:deviceName":"iPhone 11","platformName":"ios","appium:platformVersion":"13.0","appium:newCommandTimeout":0,"appium:connectHardwareKeyboard":true,"appium:allowW3C":true,"appium:w3cPrefix":"appium"},"firstMatch":[{}]},"desiredCapabilities":{"autoAcceptsAlerts":"true","automationName":"xcuitest","browserName":"safari","deviceName":"iPhone 11","platformName":"ios","platformVersion":"13.0","newCommandTimeout":0,"connectHardwareKeyboard":true,"allowW3C":true,"w3cPrefix":"appium"}}[39m
