### PR TITLE
fix: The corresponding auto generate code for Ruby in Appium is move_to an…

### DIFF
--- a/app/renderer/lib/client-frameworks/ruby.js
+++ b/app/renderer/lib/client-frameworks/ruby.js
@@ -81,7 +81,7 @@ driver.quit`;
     return `TouchAction
   .new
   .press({x: ${x1}, y: ${y1}})
-  .moveTo({x: ${x2}, y: ${y2}})
+  .move_to({x: ${x2}, y: ${y2}})
   .release
   .perform
     `;


### PR DESCRIPTION
Noticed that the auto generate code was wrong for Ruby in Appium recorder. It should be move_to instead of moveTo. Kindly merge the code and fix in the next build.