### PR TITLE
feat: Add context and some web commands as actions

### DIFF
--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -159,6 +159,22 @@ export const actionDefinitions = {
       'Get Device Settings': {methodName: 'settings'},
     },
   },
+  'Web': {
+    'Navigation': {
+      'Go to URL': {methodName: 'get', args: [['url', STRING]], refresh: true},
+      'Get URL': {methodName: 'url'},
+      'Back': {methodName: 'back', refresh: true},
+      'Forward': {methodName: 'forward', refresh: true},
+      'Refresh': {methodName: 'refresh', refresh: true}
+    }
+  },
+  'Context': {
+    'Context': {
+      'Get Context': {methodName: 'currentContext'},
+      'Get All Context': {methodName: 'contexts'},
+      'Set Context': {methodName: 'context', args: [['contextRef', STRING]], refresh: true}
+    }
+  }
 };
 
 export const INTERACTION_MODE = {


### PR DESCRIPTION
Added some commands for web/context

`methodName` were in https://github.com/admc/wd/blob/67dae3823e8a457c10d9fbe81578684bbb9938d9/doc/api.md
Command tree and their name were http://appium.io/docs/en/commands

I've tested they worked on my local