### PR TITLE
Fix click does not work on saved session item in saved capabilities tab

### DIFF
--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -90,7 +90,7 @@ export default class SavedSessions extends Component {
           pagination={false}
           dataSource={dataSource}
           columns={columns}
-          onRowClick={this.onRowClick}
+          onRowClick={this.onRow}
           rowClassName={this.getRowClassName}
         />
       </Col>


### PR DESCRIPTION
Saved session item in saved capabilities tab does not work because the `this.onRowClick` property is `undefined`. As far as checking the implementation, it looks a typo of `this.onRow`. This PR fixes it.