### PR TITLE
fix: Use treeData prop for Tree component instead of deprecated children prop

### DIFF
--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -4,7 +4,6 @@ import LocatorTestModal from './LocatorTestModal';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
-const {TreeNode} = Tree;
 const IMPORTANT_ATTRS = [
   'name',
   'content-desc',
@@ -72,9 +71,11 @@ class Source extends Component {
       if (elemObj.children.length === 0) {return null;}
 
       return elemObj.children.map((el) => {
-        return <TreeNode title={this.getFormattedTag(el)} key={el.path}>
-          {recursive(el)}
-        </TreeNode>;
+        return {
+          title: this.getFormattedTag(el),
+          key: el.path,
+          children: recursive(el),
+        };
       });
     };
 
@@ -85,9 +86,8 @@ class Source extends Component {
           autoExpandParent={false}
           expandedKeys={expandedPaths}
           onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
-          selectedKeys={[path]}>
-          {recursive(source)}
-        </Tree>
+          selectedKeys={[path]}
+          treeData={recursive(source)} />
       }
       {!source && !sourceError &&
         <i>{t('Gathering initial app source…')}</i>


### PR DESCRIPTION
I noticed following warning appeared in DevTools console:

![キャプチャ2](https://user-images.githubusercontent.com/823277/77288563-71434500-6d1b-11ea-8970-de753e67eef5.PNG)

It seems that `treeData` property should be used to set tree nodes data.

https://ant.design/components/tree/

This PR fixes the point. After applying this patch, I confirmed the warning no longer occurred and tree view worked fine by connecting to sample Android app as follows:

![キャプチャ](https://user-images.githubusercontent.com/823277/77288684-acde0f00-6d1b-11ea-952b-ef5eeeb8813d.PNG)
