### PR TITLE
fix: set Perfecto cloud provider default port when undefined

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -222,7 +222,7 @@ export function newSession (caps, attachSessId = null) {
       }
       case ServerTypes.perfecto:
         host = session.server.perfecto.hostname;
-        port = session.server.perfecto.port;
+        port = session.server.perfecto.port || 80;
         token = session.server.perfecto.token || process.env.PERFECTO_TOKEN;
         path = session.server.perfecto.path = '/nexperience/perfectomobile/wd/hub';
         if (!token) {


### PR DESCRIPTION
Sometimes the cloud port is not sent correctly from the UI, therefor setting it to the default in Session.js when it is undefined.