### PR TITLE
Fix 'Saved Session' table is not clickable

### DIFF
--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -20,9 +20,13 @@ export default class SavedSessions extends Component {
   }
 
   onRow (record) {
-    const {setCaps} = this.props;
-    let session = this.sessionFromUUID(record.key);
-    setCaps(session.caps, session.uuid);
+    return {
+      onClick: () => {
+        const {setCaps} = this.props;
+        let session = this.sessionFromUUID(record.key);
+        setCaps(session.caps, session.uuid);
+      }
+    };
   }
 
   getRowClassName (record) {
@@ -98,7 +102,7 @@ export default class SavedSessions extends Component {
           pagination={false}
           dataSource={dataSource}
           columns={columns}
-          onClick={this.onRow}
+          onRow={this.onRow}
           rowClassName={this.getRowClassName}
         />
       </Col>


### PR DESCRIPTION
I noticed saved session was not clickable. In table of 'Saved Sessions', `onClick` is used for handling click events. However, as far as I checked it seemed mistake. There is no `onClick` property.

https://ant.design/components/table/#Table

Instead, `onRow` property is available.

https://ant.design/components/table/#onRow-usage

After applying this PR, I confirmed click got effective.