### PR TITLE
fix inspector container style

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -103,6 +103,11 @@
 
 .inspector-main .tree-container {
     height: 100%;
+    overflow-y: auto;
+}
+
+.inspector-main .tree-container::-webkit-scrollbar {
+    display: none;
 }
 
 .inspector-main .tree-container :global(ul.ant-tree) {

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -29,7 +29,7 @@
     flex-direction: row;
     padding: 0em 1em 0 1em;
     max-width: 100%;
-    max-height: 100%;
+    height: calc(100% - 48px);
 }
 
 .inspector-main .screenshot-container {


### PR DESCRIPTION
Fixes two items:

1. Vertical scroll in source container https://github.com/appium/appium-desktop/issues/1316
2. Max height in the inspector container
    - Before this change, the container had `48px` redundant bottom area

![image](https://user-images.githubusercontent.com/5511591/78699164-6a811880-793e-11ea-82fc-29466edeb4c4.png)
