### PR TITLE
fix: warnings for type

### DIFF
--- a/app/renderer/components/AntdType.js
+++ b/app/renderer/components/AntdType.js
@@ -1,0 +1,6 @@
+// Button
+const BUTTON_DEFAULT = 'default';
+const BUTTON_PRIMARY = 'primary';
+const BUTTON_DISABLED = 'disabled';
+
+export { BUTTON_DEFAULT, BUTTON_PRIMARY, BUTTON_DISABLED };

--- a/app/renderer/components/Inspector/RecordedActions.js
+++ b/app/renderer/components/Inspector/RecordedActions.js
@@ -50,8 +50,6 @@ class RecordedActions extends Component {
       {frameworks[f].readableName}
     </Option>);
 
-    let boilerplateType = showBoilerplate ? 'primary' : 'default';
-
     return <div>
       {!!recordedActions.length &&
         <Select defaultValue={actionFramework} onChange={setActionFramework}
@@ -66,7 +64,7 @@ class RecordedActions extends Component {
             <Button
               onClick={toggleShowBoilerplate}
               icon={<ExportOutlined/>}
-              type={boilerplateType}
+              type={showBoilerplate ? 'primary' : 'default'}
             />
           </Tooltip>
           }

--- a/app/renderer/components/Inspector/RecordedActions.js
+++ b/app/renderer/components/Inspector/RecordedActions.js
@@ -12,6 +12,7 @@ import {
   CloseOutlined,
   CodeOutlined
 } from '@ant-design/icons';
+import { BUTTON_PRIMARY, BUTTON_DEFAULT } from '../AntdType';
 
 const Option = Select.Option;
 const ButtonGroup = Button.Group;
@@ -64,7 +65,7 @@ class RecordedActions extends Component {
             <Button
               onClick={toggleShowBoilerplate}
               icon={<ExportOutlined/>}
-              type={showBoilerplate ? 'primary' : 'default'}
+              type={showBoilerplate ? BUTTON_PRIMARY : BUTTON_DEFAULT}
             />
           </Tooltip>
           }

--- a/app/renderer/components/StartServer/DeletePresetButton.js
+++ b/app/renderer/components/StartServer/DeletePresetButton.js
@@ -4,6 +4,7 @@ import { Button } from 'antd';
 import { withTranslation } from '../../util';
 
 import styles from './StartButton.css';
+import { BUTTON_DEFAULT, BUTTON_DISABLED } from '../AntdType';
 
 class DeletePresetButton extends Component {
   render () {
@@ -12,7 +13,7 @@ class DeletePresetButton extends Component {
     return (
       <div>
         <Button className={styles.startButton}
-          type={presetDeleting ? 'disabled' : 'default'}
+          type={presetDeleting ? BUTTON_DISABLED : BUTTON_DEFAULT}
           onClick={deletePreset}
         >{presetDeleting ? t('Deleting…') : t('Delete Preset')}</Button>
       </div>

--- a/app/renderer/components/StartServer/DeletePresetButton.js
+++ b/app/renderer/components/StartServer/DeletePresetButton.js
@@ -12,7 +12,7 @@ class DeletePresetButton extends Component {
     return (
       <div>
         <Button className={styles.startButton}
-          type={presetDeleting ? 'disabled' : null}
+          type={presetDeleting ? 'disabled' : 'default'}
           onClick={deletePreset}
         >{presetDeleting ? t('Deleting…') : t('Delete Preset')}</Button>
       </div>

--- a/app/renderer/components/StartServer/SavePresetButton.js
+++ b/app/renderer/components/StartServer/SavePresetButton.js
@@ -11,7 +11,7 @@ class SavePresetButton extends Component {
     return (
       <div>
         <Button className={styles.startButton}
-          type={presetSaving ? 'disabled' : ''}
+          type={presetSaving ? 'disabled' : 'default'}
           onClick={savePreset}
         >{presetSaving ? t('Saving…') : t('Save As Preset…')}</Button>
         <input type="submit" hidden={true} />

--- a/app/renderer/components/StartServer/SavePresetButton.js
+++ b/app/renderer/components/StartServer/SavePresetButton.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Button } from 'antd';
 import { withTranslation } from '../../util';
 import styles from './StartButton.css';
+import { BUTTON_DEFAULT, BUTTON_DISABLED } from '../AntdType';
 
 class SavePresetButton extends Component {
   render () {
@@ -11,7 +12,7 @@ class SavePresetButton extends Component {
     return (
       <div>
         <Button className={styles.startButton}
-          type={presetSaving ? 'disabled' : 'default'}
+          type={presetSaving ? BUTTON_DISABLED : BUTTON_DEFAULT}
           onClick={savePreset}
         >{presetSaving ? t('Saving…') : t('Save As Preset…')}</Button>
         <input type="submit" hidden={true} />

--- a/app/renderer/components/StartServer/StartServer.js
+++ b/app/renderer/components/StartServer/StartServer.js
@@ -37,13 +37,13 @@ export default class StartServer extends Component {
           <img src={AppiumLogo} className={styles.logo} />
           <div className={styles.tabs}>
             <Button.Group className={styles.tabButtons}>
-              <Button type={tabId === TAB_SIMPLE ? 'primary' : null }
+              <Button type={tabId === TAB_SIMPLE ? 'primary' : 'default' }
                 onClick={() => switchTab(TAB_SIMPLE)}
               >{t('Simple')}</Button>
-              <Button type={tabId === TAB_ADVANCED ? 'primary' : null }
+              <Button type={tabId === TAB_ADVANCED ? 'primary' : 'default' }
                 onClick={() => switchTab(TAB_ADVANCED)}
               >{t('Advanced')}</Button>
-              <Button type={tabId === TAB_PRESETS ? 'primary' : null }
+              <Button type={tabId === TAB_PRESETS ? 'primary' : 'default' }
                 onClick={() => switchTab(TAB_PRESETS)}
               >{t('Presets')}</Button>
             </Button.Group>

--- a/app/renderer/components/StartServer/StartServer.js
+++ b/app/renderer/components/StartServer/StartServer.js
@@ -9,6 +9,7 @@ import PresetsTab from './PresetsTab';
 import styles from './StartServer.css';
 
 import AppiumLogo from '../../images/appium_logo.png';
+import { BUTTON_PRIMARY, BUTTON_DEFAULT } from '../AntdType';
 
 const TAB_SIMPLE = 0, TAB_ADVANCED = 1, TAB_PRESETS = 2;
 
@@ -37,13 +38,13 @@ export default class StartServer extends Component {
           <img src={AppiumLogo} className={styles.logo} />
           <div className={styles.tabs}>
             <Button.Group className={styles.tabButtons}>
-              <Button type={tabId === TAB_SIMPLE ? 'primary' : 'default' }
+              <Button type={tabId === TAB_SIMPLE ? BUTTON_PRIMARY : BUTTON_DEFAULT }
                 onClick={() => switchTab(TAB_SIMPLE)}
               >{t('Simple')}</Button>
-              <Button type={tabId === TAB_ADVANCED ? 'primary' : 'default' }
+              <Button type={tabId === TAB_ADVANCED ? BUTTON_PRIMARY : BUTTON_DEFAULT }
                 onClick={() => switchTab(TAB_ADVANCED)}
               >{t('Advanced')}</Button>
-              <Button type={tabId === TAB_PRESETS ? 'primary' : 'default' }
+              <Button type={tabId === TAB_PRESETS ? BUTTON_PRIMARY : BUTTON_DEFAULT }
                 onClick={() => switchTab(TAB_PRESETS)}
               >{t('Presets')}</Button>
             </Button.Group>


### PR DESCRIPTION
Fixes warnings about `type`. Their default should be `default`. `default` is used in some places, but not rest of them are still `null` or `''` (blank)
https://ant.design/components/button/

They seem okay, but let me check them again later