### PR TITLE
chore: update bot cycle weekly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     ignored_updates:
       - match:
           dependency_name: "electron"


### PR DESCRIPTION
dependabot/config.yml does not support format like ignoring only `patch`, but we want to reduce PR frequency.
Let me change the update schedule to weekly for now