### PR TITLE
chore: bump version to run ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.17.1",
+  "version": "1.17.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.17.1",
+  "version": "1.17.1-1",
   "description": "Graphical interface for the Appium server, and an app inspector",
   "repository": {
     "type": "git",


### PR DESCRIPTION
like https://github.com/appium/appium-desktop/commit/c5e8190075c16591174844d59076830214206270 (1.15.0-1).
This is necessary before https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=9936&view=logs&j=52ae2be2-cccc-589a-915f-9637704a0c53&t=20f9c7c9-e480-56d1-56b3-bbd543d49b14 ...