### PR TITLE
fix: no children in source

### DIFF
--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -67,9 +67,7 @@ class Source extends Component {
 
     // Recursives through the source and renders a TreeNode for an element
     let recursive = (elemObj) => {
-      if (!elemObj) {return null;}
-      if (!elemObj.children) {return null;}
-      if (elemObj.children.length === 0) {return null;}
+      if (!elemObj?.children?.length) {return null;}
 
       return elemObj.children.map((el) => ({
         title: this.getFormattedTag(el),

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -68,6 +68,7 @@ class Source extends Component {
     // Recursives through the source and renders a TreeNode for an element
     let recursive = (elemObj) => {
       if (!elemObj) {return null;}
+      if (!elemObj.children) {return null;}
       if (elemObj.children.length === 0) {return null;}
 
       return elemObj.children.map((el) => ({

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -67,7 +67,7 @@ class Source extends Component {
 
     // Recursives through the source and renders a TreeNode for an element
     let recursive = (elemObj) => {
-      if (!((elemObj || {}).children || []).length) { return null; }
+      if (!((elemObj || {}).children || []).length) {return null;}
 
       return elemObj.children.map((el) => ({
         title: this.getFormattedTag(el),

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -67,7 +67,7 @@ class Source extends Component {
 
     // Recursives through the source and renders a TreeNode for an element
     let recursive = (elemObj) => {
-      if (!((elemObj || {}).children || []).length) return null
+      if (!((elemObj || {}).children || []).length) { return null; }
 
       return elemObj.children.map((el) => ({
         title: this.getFormattedTag(el),

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -67,7 +67,7 @@ class Source extends Component {
 
     // Recursives through the source and renders a TreeNode for an element
     let recursive = (elemObj) => {
-      if (!elemObj?.children?.length) {return null;}
+      if (!((elemObj || {}).children || []).length) return null
 
       return elemObj.children.map((el) => ({
         title: this.getFormattedTag(el),


### PR DESCRIPTION
fix https://github.com/appium/appium-desktop/issues/1449
`elemObj.children` could be undefined.