### PR TITLE
fix: keep compatibility in _getContextsSourceAndScreenshot for platforms which have no context commands

### DIFF
--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -184,7 +184,7 @@ export default class AppiumMethodHandler {
    * @returns {boolean} True if the platformName support context switch
    *
    */
-  _hasContextSwitch (platformName) {
+  _hasContextCommands (platformName) {
     return (['android', 'ios'].includes(_.toLower(platformName)));
   }
 
@@ -198,7 +198,7 @@ export default class AppiumMethodHandler {
       ({platformName, statBarHeight} = await this.driver.sessionCapabilities());
     } catch (ign) { }
 
-    if (!this._hasContextSwitch(platformName)) {
+    if (!this._hasContextCommands(platformName)) {
       currentContext = NATIVE_APP;
       contexts = [NATIVE_APP];
     } else {

--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -176,7 +176,10 @@ export default class AppiumMethodHandler {
 
   /**
    * If the platformName has context switch command.
-   * tvOS, Windows an
+   * Windows, macOS etc may have no an ability to calls contexts related commands.
+   * tvOS also has no ability to support WebView so far.
+   * So, for now, we want to avoid calling contexts related command to them.
+   *
    * @param {?string} platformName Platform name to check if it support contexts command
    * @returns {boolean} True if the platformName support context switch
    *

--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -177,21 +177,25 @@ export default class AppiumMethodHandler {
   /**
    * If the app under test can return contexts command.
    *
-   * @returns {boolean} True if the platformName support context switch
+   * @returns {boolean} True if the app under test supports contexts command.
    *
    */
-  async _hasContextCommands () {
-    const { error } = await this.driver.contexts();
-    return !error;
+  async _hasContextsCommand () {
+    try {
+      const { error } = await this.driver.contexts();
+      return !error;
+    } catch (ign) { }
+    // If the app under test returns non JSON format response
+    return false;
   }
 
   async _getContextsSourceAndScreenshot () {
     let contexts, contextsError, currentContext, currentContextError, platformName,
         source, sourceError, screenshot, screenshotError, statBarHeight, windowSize, windowSizeError;
 
-    if (!await this._hasContextCommands()) {
-      currentContext = NATIVE_APP;
-      contexts = [NATIVE_APP];
+    if (!await this._hasContextsCommand()) {
+      currentContext = null;
+      contexts = [];
     } else {
       try {
         currentContext = await this.driver.currentContext();
@@ -271,7 +275,7 @@ export default class AppiumMethodHandler {
    * Retrieve available contexts, along with the title associated with each webview
    */
   async _getContexts (platform) {
-    return platform.toLowerCase() === 'ios' ? await this.driver.execute('mobile:getContexts', []) : await this._getAndroidContexts();
+    return _.toLower(platform) === 'ios' ? await this.driver.execute('mobile:getContexts', []) : await this._getAndroidContexts();
   }
 
   /**

--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -175,30 +175,21 @@ export default class AppiumMethodHandler {
   }
 
   /**
-   * If the platformName has context switch command.
-   * Windows, macOS etc may have no an ability to calls contexts related commands.
-   * tvOS also has no ability to support WebView so far.
-   * So, for now, we want to avoid calling contexts related command to them.
+   * If the app under test can return contexts command.
    *
-   * @param {?string} platformName Platform name to check if it support contexts command
    * @returns {boolean} True if the platformName support context switch
    *
    */
-  _hasContextCommands (platformName) {
-    return (['android', 'ios'].includes(_.toLower(platformName)));
+  async _hasContextCommands () {
+    const { error } = await this.driver.contexts();
+    return !error;
   }
 
   async _getContextsSourceAndScreenshot () {
     let contexts, contextsError, currentContext, currentContextError, platformName,
         source, sourceError, screenshot, screenshotError, statBarHeight, windowSize, windowSizeError;
 
-    // Get current session capabilities is not in W3C spec,
-    // so potentially the request fails. Then, let's ignore the result.
-    try {
-      ({platformName, statBarHeight} = await this.driver.sessionCapabilities());
-    } catch (ign) { }
-
-    if (!this._hasContextCommands(platformName)) {
+    if (!await this._hasContextCommands()) {
       currentContext = NATIVE_APP;
       contexts = [NATIVE_APP];
     } else {
@@ -216,6 +207,7 @@ export default class AppiumMethodHandler {
         await this.driver.context(NATIVE_APP);
       }
 
+      ({platformName, statBarHeight} = await this.driver.sessionCapabilities());
 
       try {
         windowSize = await this.driver.getWindowSize();

--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -123,8 +123,10 @@ export default class HighlighterRects extends Component {
         xOffset={highlighterXOffset}
       />);
 
-      for (let childEl of element.children) {
-        recursive(childEl, zIndex + 1);
+      if (element.children) {
+        for (let childEl of element.children) {
+          recursive(childEl, zIndex + 1);
+        }
       }
     };
 


### PR DESCRIPTION
https://github.com/appium/appium-desktop/pull/1438 introduced context-related commands, but some platform does not support them like Windows and macOS (https://github.com/appium/appium-desktop/issues/1449#issuecomment-655966896) .
We should keep the previous way for such platforms.

In this PR, AD will follow the previous logic if the app under test does not have get contexts command.
I also fixed some errors I found in tests.