### PR TITLE
fix: print the original error response if given error message has the original error for findElements

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -88,7 +88,7 @@ export function showError (e, methodName, secs = 5) {
     }
     errMessage = i18n.t('findElementFailure', {methodName});
     if (e.message) {
-      errMessage += ` Original error: ${e.message}`;
+      errMessage += ` Original error: '${e.message}'`;
     }
   } else if (e.data) {
     try {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -81,8 +81,9 @@ export function getCapsObject (caps) {
 export function showError (e, methodName, secs = 5) {
   let errMessage;
   if (e['jsonwire-error'] && e['jsonwire-error'].status === 7) {
+    // FIXME: we probably should set 'findElement' as the method name
+    // if it is also number.
     if (methodName === 10) {
-      // It seems find elements is 10
       methodName = 'findElements';
     }
     errMessage = i18n.t('findElementFailure', {methodName});

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -81,7 +81,14 @@ export function getCapsObject (caps) {
 export function showError (e, methodName, secs = 5) {
   let errMessage;
   if (e['jsonwire-error'] && e['jsonwire-error'].status === 7) {
+    if (methodName === 10) {
+      // It seems find elements is 10
+      methodName = 'findElements';
+    }
     errMessage = i18n.t('findElementFailure', {methodName});
+    if (e.message) {
+      errMessage += ` Original error: ${e.message}`;
+    }
   } else if (e.data) {
     try {
       e.data = JSON.parse(e.data);


### PR DESCRIPTION
AD currently shows below message as the result of findElements via an icon when the given parameter is an invalid selector.
For example, my below screenshot is for macOS, but I sent a selector for Android.

```
Call to '10' failed
[elements("-android datamatcher","asd")] Response value field is not an Array.
```

I could not find `findElement` request via icon and actions. So, I only tweaked this case since I could not replicate an error case for `findElement`.

![image](https://user-images.githubusercontent.com/5511591/87879837-12bb7880-ca28-11ea-877f-43a5891087ad.png)


This change does not affect a case which it returns `[]`.

---

closes https://github.com/appium/appium-desktop/issues/1470