### PR TITLE
chore: bump AD version to 1.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.18.0-beta.1",
+  "version": "1.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.18.0-beta.1",
+  "version": "1.18.0",
   "description": "Graphical interface for the Appium server, and an app inspector",
   "repository": {
     "type": "git",


### PR DESCRIPTION
for pre-1.18.0 repease