### PR TITLE
fix: attach to an existing session

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -171,7 +171,7 @@ export function newSession (caps, attachSessId = null) {
 
     dispatch({type: NEW_SESSION_REQUESTED, caps});
 
-    let desiredCapabilities = caps ? getCapsObject(caps) : null;
+    let desiredCapabilities = caps ? getCapsObject(caps) : {};
     let session = getState().session;
     let host, port, username, accessKey, https, path, token;
     desiredCapabilities = addCustomCaps(desiredCapabilities);


### PR DESCRIPTION
Closes https://github.com/appium/appium-desktop/issues/1505

Attach to an existing session is `newSession(null, attachSessId)`. Then, `addCustomCaps(null)` raises an error in `const {browserName = '', platformName = ''} = caps;`. `{}` works both cases.