### PR TITLE
chore: bump to 1.18.0-1 as a hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.18.0",
+  "version": "1.18.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-desktop",
-  "version": "1.18.0",
+  "version": "1.18.0-1",
   "description": "Graphical interface for the Appium server, and an app inspector",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Current 1.18.0 has an issue to attach to an existing session. (The feature is not available at all)
https://github.com/appium/appium-desktop/issues/1505