### PR TITLE
fix: get filePaths

### DIFF
--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -9,12 +9,12 @@ const {dialog} = remote;
 
 export default class NewSessionForm extends Component {
 
-  async getLocalFilePath (success) {
-    await dialog.showOpenDialog({
+  getLocalFilePath (success) {
+    dialog.showOpenDialog({
       properties: ['openFile'],
-    }).then((files) => {
-      if (files.filePaths) {
-        success(files.filePaths);
+    }).then((result) => {
+      if (result.filePaths) {
+        success(result.filePaths);
       }
     }).catch(/* ignore */);
   }

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -27,10 +27,7 @@ export default class NewSessionForm extends Component {
 
     const buttonAfter = (currentFilePath) => <FileOutlined
       className={SessionStyles['filepath-button']}
-      onClick={async () => {
-        const filePath = await this.getLocalFilePath();
-        onSetCapabilityParam(filePath ? filePath : currentFilePath) ;
-      }} />;
+      onClick={async () => {onSetCapabilityParam(await this.getLocalFilePath() || currentFilePath);}} />;
 
     switch (cap.type) {
       case 'text': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} onChange={(e) => onSetCapabilityParam(e.target.value)} />;

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -25,11 +25,11 @@ export default class NewSessionForm extends Component {
   render () {
     const {cap, onSetCapabilityParam, isEditingDesiredCaps, id, t} = this.props;
 
-    const buttonAfter = (currentPath) => <FileOutlined
+    const buttonAfter = (currentFilePath) => <FileOutlined
       className={SessionStyles['filepath-button']}
       onClick={async () => {
         const filePath = await this.getLocalFilePath();
-        onSetCapabilityParam(filePath ? filePath : currentPath) ;
+        onSetCapabilityParam(filePath ? filePath : currentFilePath) ;
       }} />;
 
     switch (cap.type) {

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -11,20 +11,25 @@ const {dialog} = remote;
 
 export default class NewSessionForm extends Component {
 
+  async getLocalFilePath () {
+    try {
+      const {canceled, filePaths} = await dialog.showOpenDialog({properties: ['openFile']});
+      if (!canceled && !_.isEmpty(filePaths)) {
+        return filePaths[0];
+      }
+    } catch (e) {
+      log.error(e);
+    }
+  }
+
   render () {
     const {cap, onSetCapabilityParam, isEditingDesiredCaps, id, t} = this.props;
 
     const buttonAfter = (currentPath) => <FileOutlined
       className={SessionStyles['filepath-button']}
       onClick={async () => {
-        try {
-          const {canceled, filePaths} = await dialog.showOpenDialog({properties: ['openFile']});
-          let returnPath = currentPath;
-          if (!canceled && !_.isEmpty(filePaths)) {returnPath = filePaths[0];}
-          onSetCapabilityParam(returnPath);
-        } catch (e) {
-          log.error(e);
-        }
+        const filePath = await this.getLocalFilePath();
+        onSetCapabilityParam(filePath ? filePath : currentPath) ;
       }} />;
 
     switch (cap.type) {

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -7,16 +7,16 @@ import { INPUT } from '../AntdTypes';
 
 const {dialog} = remote;
 
-
 export default class NewSessionForm extends Component {
 
-  getLocalFilePath (success) {
-    dialog.showOpenDialog((filepath) => {
-      if (filepath) {
-        success(filepath);
+  async getLocalFilePath (success) {
+    await dialog.showOpenDialog({
+      properties: ['openFile'],
+    }).then((files) => {
+      if (files.filePaths) {
+        success(files.filePaths);
       }
-    });
-    this.handleSetType = this.handleSetType.bind(this);
+    }).catch(/* ignore */);
   }
 
   render () {
@@ -24,7 +24,7 @@ export default class NewSessionForm extends Component {
 
     const buttonAfter = <FileOutlined
       className={SessionStyles['filepath-button']}
-      onClick={() => this.getLocalFilePath((filepath) => onSetCapabilityParam(filepath[0]))} />;
+      onClick={() => this.getLocalFilePath((filePaths) => onSetCapabilityParam(filePaths[0]))} />;
 
     switch (cap.type) {
       case 'text': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} onChange={(e) => onSetCapabilityParam(e.target.value)} />;


### PR DESCRIPTION
closes https://github.com/appium/appium-desktop/issues/1492

Not sure since when, but `showOpenDialog` should be `then` syntax.
`this.handleSetType` is always `null`, so cannot bind.

After:
![image](https://user-images.githubusercontent.com/5511591/90305457-0d096380-defe-11ea-9913-53dc4c604898.png)

https://github.com/electron/electron/blob/v6.0.0/docs/api/dialog.md#dialogshowopendialogbrowserwindow-options