### PR TITLE
feat: add Sauce Labs Unified Platform endpoint for US

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -194,8 +194,7 @@ export function newSession (caps, attachSessId = null) {
         https = session.server.remote.ssl;
         break;
       case ServerTypes.sauce:
-        host = session.server.sauce.dataCenter === 'eu-central-1' ?
-          'ondemand.eu-central-1.saucelabs.com' : 'ondemand.saucelabs.com';
+        host = `ondemand.${session.server.sauce.dataCenter}.saucelabs.com`;
         port = 80;
         if (session.server.sauce.useSCProxy) {
           host = session.server.sauce.scHost || 'localhost';

--- a/app/renderer/components/Session/ServerTabSauce.js
+++ b/app/renderer/components/Session/ServerTabSauce.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Form, Row, Col, Input, Checkbox, Radio } from 'antd';
+import { Form, Row, Col, Input, Checkbox, Radio, Tooltip } from 'antd';
 import SessionStyles from './Session.css';
 import { INPUT } from '../AntdTypes';
 const FormItem = Form.Item;
@@ -34,8 +34,10 @@ export default class ServerTabSauce extends Component {
         <Col span={24}>
           <FormItem>
             <div className={['ant-input-group-addon', SessionStyles.addonDataCenter].join(' ') }>{t('SauceLabs Data Center')}</div>
-            <Radio.Group className={SessionStyles.inputDataCenter} buttonStyle="solid" defaultValue='us-west-1' id='sauceObjectDataCenter' value={server.sauce.dataCenter} onChange={(e) => setServerParam('dataCenter', e.target.value)}>
-              <Radio value='us-west-1'>{t('US')}</Radio>
+            <Radio.Group className={[SessionStyles.inputDataCenter, SessionStyles.addonDataCenterRadioContainer].join(' ')} buttonStyle="solid" defaultValue='us-west-1' id='sauceObjectDataCenter' value={server.sauce.dataCenter} onChange={(e) => setServerParam('dataCenter', e.target.value)}>
+              <Tooltip placement="top" title={t('UP')}>
+                <Radio value='us-west-1'>{t('US')}</Radio>
+              </Tooltip>
               <Radio value='eu-central-1'>{t('EU')}</Radio>
             </Radio.Group>
           </FormItem>

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -236,3 +236,9 @@
   height: 32px;
   border-right: 1px solid #d9d9d9 !important;
 }
+
+.addonDataCenterRadioContainer {
+  line-height: 32px;
+  display: table-cell;
+  padding-left: 11px;
+}

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -199,6 +199,7 @@
   "SauceLabs Data Center": "SauceLabs Data Center",
   "US": "US",
   "EU": "EU",
+  "UP": "Appium Desktop will use the new Sauce Labs Unified Platform endpoint the the US by default. If you want to use the old US endpoint then do the following: Go to 'Custom server', add 'ondemand.saucelabs.com' as a remote host, use port '433'<br/>, the remote path is ''/wd/hub<br/> and last but not least enable 'SSL'",
   "proxyThroughSC": "Proxy through Sauce Connect's Selenium Relay",
   "SSL": "SSL",
   "text": "text",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -199,7 +199,7 @@
   "SauceLabs Data Center": "SauceLabs Data Center",
   "US": "US",
   "EU": "EU",
-  "UP": "Appium Desktop will use the new Sauce Labs Unified Platform endpoint the the US by default. If you want to use the old US endpoint then do the following: Go to 'Custom server', add 'ondemand.saucelabs.com' as a remote host, use port '433', the remote path is ''/wd/hub and last but not least enable 'SSL'",
+  "UP": "Appium Desktop will use the new Sauce Labs Unified Platform US endpoint by default. If you want to use the old US endpoint then do the following: Go to the 'Custom server'-tab, add 'ondemand.saucelabs.com' as a remote host, use port '433', the remote path is '/wd/hub' and last but not least enable 'SSL'.",
   "proxyThroughSC": "Proxy through Sauce Connect's Selenium Relay",
   "SSL": "SSL",
   "text": "text",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -199,7 +199,7 @@
   "SauceLabs Data Center": "SauceLabs Data Center",
   "US": "US",
   "EU": "EU",
-  "UP": "Appium Desktop will use the new Sauce Labs Unified Platform endpoint the the US by default. If you want to use the old US endpoint then do the following: Go to 'Custom server', add 'ondemand.saucelabs.com' as a remote host, use port '433'<br/>, the remote path is ''/wd/hub<br/> and last but not least enable 'SSL'",
+  "UP": "Appium Desktop will use the new Sauce Labs Unified Platform endpoint the the US by default. If you want to use the old US endpoint then do the following: Go to 'Custom server', add 'ondemand.saucelabs.com' as a remote host, use port '433', the remote path is ''/wd/hub and last but not least enable 'SSL'",
   "proxyThroughSC": "Proxy through Sauce Connect's Selenium Relay",
   "SSL": "SSL",
   "text": "text",


### PR DESCRIPTION
This PR will:

- add the new Sauce Labs Unified Platform US endpoint as the default
- fixes the layout to a normal row
![image](https://user-images.githubusercontent.com/11979740/91629844-c5d6a480-e9cc-11ea-8ba3-c13cc9401707.png)
- Adds a tooltip with information on how to use the old endpoint
![image](https://user-images.githubusercontent.com/11979740/91629890-1f3ed380-e9cd-11ea-942f-2b0a667047d9.png)
