### PR TITLE
fix: send wrong session id

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -616,4 +616,3 @@ export function callClientMethod (params) {
     return res;
   };
 }
-

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -53,7 +53,9 @@ export const IS_ADDING_CLOUD_PROVIDER = 'IS_ADDING_CLOUD_PROVIDER';
 
 export const SET_PROVIDERS = 'SET_PROVIDERS';
 
-export const CONN_RETRIES = 2;
+// Multiple request sometimes send a new session request
+// after establishing a session
+export const CONN_RETRIES = 0;
 
 const serverTypes = {};
 for (const key of keys(CloudProviders)) {
@@ -747,10 +749,6 @@ function addCustomCaps (caps) {
   const chromeCustomCaps = {
     // Make sure the screenshot is taken of the whole screen when the ChromeDriver is used
     nativeWebScreenshot: true,
-    // Set the ChromeDriver to w3c:false because all internal calls are still JSONWP calls
-    chromeOptions: {
-      'w3c': false,
-    },
   };
   const androidCustomCaps = {
     // @TODO: remove when this is defaulted in the newest Appium 1.8.x release

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -53,8 +53,11 @@ export const IS_ADDING_CLOUD_PROVIDER = 'IS_ADDING_CLOUD_PROVIDER';
 
 export const SET_PROVIDERS = 'SET_PROVIDERS';
 
-// Multiple request sometimes send a new session request
-// after establishing a session
+// Multiple requests sometimes send a new session request
+// after establishing a session.
+// This situation could happen easier on cloud vendors,
+// so let's set zero so far.
+// TODO: increase this retry when we get issues
 export const CONN_RETRIES = 0;
 
 const serverTypes = {};

--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -176,6 +176,13 @@ export const actionDefinitions = {
       'Get Context': {methodName: 'getContext'},
       'Get All Context': {methodName: 'getContexts'},
       'Set Context': {methodName: 'switchContexts', args: [['name', STRING]], refresh: true}
+    },
+    'Window (W3C)': {
+      'Get Window Handle': {methodName: 'getWindowHandle'},
+      'Close Window': {methodName: 'closeWindow', refresh: true},
+      'Switch To Window': {methodName: 'switchToWindow', args: [['handle', STRING]], refresh: true},
+      'Get Window Handles': {methodName: 'getWindowHandles'},
+      'New Window': {methodName: 'createWindow', args: [['type', STRING]], refresh: true}
     }
   }
 };

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -30,6 +30,9 @@ export default class AppiumClient {
       try {
         await this.driver.quit();
       } catch (ign) {}
+
+      _instance = null;
+
       // when we've quit the session, there's no source/screenshot to send
       // back
       return {


### PR DESCRIPTION
fixes https://github.com/appium/appium-desktop/issues/1596

We missed to clean current client instance in quit the session, so the instance remains in next one.
Then, the next session send requests as the previous session_id. Then, it gets invalid session error.


---

I also added W3C command since we know can follow W3C spec as primary method