### PR TITLE
add: a link to translation project in help for non-macOS env

### DIFF
--- a/shared/menus.js
+++ b/shared/menus.js
@@ -275,6 +275,11 @@ function otherMenuHelp ({i18n, shell}) {
       click () {
         shell.openExternal('https://github.com/appium/appium-desktop/issues');
       }
+    }, {
+      label: i18n.t('Add Or Improve Translations'),
+      click () {
+        shell.openExternal('https://crowdin.com/project/appium-desktop');
+      }
     }]
   };
 }


### PR DESCRIPTION
This item will be at the bottom of the below list.

![image](https://user-images.githubusercontent.com/5511591/101326913-4c92fb80-38b1-11eb-9de5-e5a4ddd77e8d.png)
