### PR TITLE
fix: getRunningSessions for BrowserStack & other cloud providers that use basicAuth

### DIFF
--- a/inspector/app/renderer/actions/Session.js
+++ b/inspector/app/renderer/actions/Session.js
@@ -257,7 +257,7 @@ export function newSession (caps, attachSessId = null) {
         break;
       case ServerTypes.browserstack:
         host = session.server.browserstack.hostname = process.env.BROWSERSTACK_HOST || 'hub-cloud.browserstack.com';
-        port = session.server.browserstack.port = session.server.browserstack.port = 443;
+        port = session.server.browserstack.port = process.env.BROWSERSTACK_PORT || 443;
         path = session.server.browserstack.path = '/wd/hub';
         username = session.server.browserstack.username || process.env.BROWSERSTACK_USERNAME;
         desiredCapabilities['browserstack.source'] = 'appiumdesktop';
@@ -270,7 +270,7 @@ export function newSession (caps, attachSessId = null) {
           });
           return;
         }
-        https = session.server.browserstack.ssl = true;
+        https = session.server.browserstack.ssl = (parseInt(port, 10) === 443);
         break;
       case ServerTypes.bitbar:
         host = process.env.BITBAR_HOST || 'appium.bitbar.com';

--- a/inspector/app/renderer/actions/Session.js
+++ b/inspector/app/renderer/actions/Session.js
@@ -256,8 +256,8 @@ export function newSession (caps, attachSessId = null) {
         https = session.server.perfecto.ssl = false;
         break;
       case ServerTypes.browserstack:
-        host = process.env.BROWSERSTACK_HOST || 'hub-cloud.browserstack.com';
-        port = session.server.browserstack.port = 443;
+        host = session.server.browserstack.hostname = process.env.BROWSERSTACK_HOST || 'hub-cloud.browserstack.com';
+        port = session.server.browserstack.port = session.server.browserstack.port = 443;
         path = session.server.browserstack.path = '/wd/hub';
         username = session.server.browserstack.username || process.env.BROWSERSTACK_USERNAME;
         desiredCapabilities['browserstack.source'] = 'appiumdesktop';
@@ -631,7 +631,7 @@ export function getRunningSessions () {
     const state = getState().session;
     const {server, serverType} = state;
     const serverInfo = server[serverType];
-    const {hostname, port, path, ssl} = serverInfo;
+    const {hostname, port, path, ssl, username, accessKey} = serverInfo;
 
     if (!hostname || !port || !path) {
       // no need to get sessions if we don't have complete server info
@@ -646,7 +646,17 @@ export function getRunningSessions () {
 
     try {
       const adjPath = path.endsWith('/') ? path : `${path}/`;
-      const res = await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`).json();
+      let res;
+      if (username && accessKey) {
+        // add basic auth for some cloud providers
+        res = await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`, {
+          headers: {
+            'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`
+          }
+        }).json();
+      } else {
+        res = await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`).json();
+      }
       dispatch({type: GET_SESSIONS_DONE, sessions: res.value});
     } catch (err) {
       console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console

--- a/inspector/app/renderer/actions/Session.js
+++ b/inspector/app/renderer/actions/Session.js
@@ -646,17 +646,11 @@ export function getRunningSessions () {
 
     try {
       const adjPath = path.endsWith('/') ? path : `${path}/`;
-      let res;
-      if (username && accessKey) {
-        // add basic auth for some cloud providers
-        res = await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`, {
-          headers: {
-            'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`
-          }
-        }).json();
-      } else {
-        res = await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`).json();
-      }
+      const res = username && accessKey
+        ? await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`, {
+          headers: {'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`}
+        }).json()
+        : await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`).json();
       dispatch({type: GET_SESSIONS_DONE, sessions: res.value});
     } catch (err) {
       console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console


### PR DESCRIPTION
1. The "Attach to session" tab of the inspector window doesn't list the running sessions for BrowserStack, this happens because the BrowserStack APIs require the user credentials otherwise it returns a response code of 401.
2. This PR adds the `Authorization` header for the `/wd/hub/sessions` requests.