### PR TITLE
fix: getCurrentSessions for cloud providers using Basic Auth

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -330,9 +330,15 @@ function connectClientMethodListener () {
 }
 
 const getCurrentSessions = _.debounce(async (evt, data) => {
-  const {host, port, path: appiumPath = '/wd/hub', ssl} = data;
+  const {host, port, path: appiumPath = '/wd/hub', ssl, username, accessKey} = data;
+  let res;
   try {
-    const res = await request(`http${ssl ? 's' : ''}://${host}:${port}${appiumPath}/sessions`);
+    if (username && accessKey) {
+      // Basic Authorization for some cloud providers
+      res = await request(`http${ssl ? 's' : ''}://${username}:${accessKey}@${host}:${port}${appiumPath}/sessions`);
+    } else {
+      res = await request(`http${ssl ? 's' : ''}://${host}:${port}${appiumPath}/sessions`);
+    }
     evt.sender.send('appium-client-get-sessions-response', {res});
   } catch (e) {
     evt.sender.send('appium-client-get-sessions-fail');

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -331,14 +331,10 @@ function connectClientMethodListener () {
 
 const getCurrentSessions = _.debounce(async (evt, data) => {
   const {host, port, path: appiumPath = '/wd/hub', ssl, username, accessKey} = data;
-  let res;
   try {
-    if (username && accessKey) {
-      // Basic Authorization for some cloud providers
-      res = await request(`http${ssl ? 's' : ''}://${username}:${accessKey}@${host}:${port}${appiumPath}/sessions`);
-    } else {
-      res = await request(`http${ssl ? 's' : ''}://${host}:${port}${appiumPath}/sessions`);
-    }
+    const res = username && accessKey
+      ? await request(`http${ssl ? 's' : ''}://${username}:${accessKey}@${host}:${port}${appiumPath}/sessions`)
+      : await request(`http${ssl ? 's' : ''}://${host}:${port}${appiumPath}/sessions`);
     evt.sender.send('appium-client-get-sessions-response', {res});
   } catch (e) {
     evt.sender.send('appium-client-get-sessions-fail');

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -245,7 +245,7 @@ export function newSession (caps, attachSessId = null) {
         https = session.server.perfecto.ssl = false;
         break;
       case ServerTypes.browserstack:
-        host = process.env.BROWSERSTACK_HOST || 'hub-cloud.browserstack.com';
+        host = session.server.browserstack.hostname = process.env.BROWSERSTACK_HOST || 'hub-cloud.browserstack.com';
         port = session.server.browserstack.port = 443;
         path = session.server.browserstack.path = '/wd/hub';
         username = session.server.browserstack.username || process.env.BROWSERSTACK_USERNAME;
@@ -599,7 +599,12 @@ export function getRunningSessions () {
       dispatch({type: GET_SESSIONS_DONE});
     } else {
       ipcRenderer.send('appium-client-get-sessions', {
-        host: serverInfo.hostname, port: serverInfo.port, path: serverInfo.path, ssl: serverInfo.ssl
+        host: serverInfo.hostname,
+        port: serverInfo.port,
+        path: serverInfo.path,
+        ssl: serverInfo.ssl,
+        username: serverInfo.username,
+        accessKey: serverInfo.accessKey
       });
       ipcRenderer.once('appium-client-get-sessions-response', (evt, e) => {
         const res = JSON.parse(e.res);

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -246,7 +246,7 @@ export function newSession (caps, attachSessId = null) {
         break;
       case ServerTypes.browserstack:
         host = session.server.browserstack.hostname = process.env.BROWSERSTACK_HOST || 'hub-cloud.browserstack.com';
-        port = session.server.browserstack.port = 443;
+        port = session.server.browserstack.port = process.env.BROWSERSTACK_PORT || 443;
         path = session.server.browserstack.path = '/wd/hub';
         username = session.server.browserstack.username || process.env.BROWSERSTACK_USERNAME;
         desiredCapabilities['browserstack.source'] = 'appiumdesktop';
@@ -259,7 +259,7 @@ export function newSession (caps, attachSessId = null) {
           });
           return;
         }
-        https = session.server.browserstack.ssl = true;
+        https = session.server.browserstack.ssl = (parseInt(port, 10) === 443);
         break;
       case ServerTypes.bitbar:
         host = process.env.BITBAR_HOST || 'appium.bitbar.com';


### PR DESCRIPTION
1. The "Attach to session" tab of the inspector app doesn't return the running sessions for BrowserStack, this happens because the BrowserStack APIs require the user credentials otherwise it returns a response code of 401.
2. This PR adds the Authorization header for the `/wd/hub/sessions` requests i.e. for `getCurrentSessions`
3. Also add the ability to use the `BROWSERSTACK_PORT` set in the environment variables for defining the port and setting SSL to true if the port is 443.