### PR TITLE
feat: add sessionName in the attach to session dropdown

### DIFF
--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -4,6 +4,7 @@ import SessionCSS from './Session.css';
 import {
   ReloadOutlined
 } from '@ant-design/icons';
+import {ServerTypes} from '../../actions/Session';
 
 const FormItem = Form.Item;
 
@@ -12,6 +13,11 @@ function formatCaps (caps) {
   if (caps.automationName) {
     importantCaps.push(caps.automationName);
   }
+  return importantCaps.join(', ').trim();
+}
+
+function formatCapsBrowserstack (caps) {
+  let importantCaps = formatCaps(caps).split(', ');
   if (caps.sessionName) {
     importantCaps.push(caps.sessionName);
   }
@@ -20,12 +26,16 @@ function formatCaps (caps) {
 
 export default class AttachToSession extends Component {
 
-  getSessionInfo (session) {
-    return `${session.id} — ${formatCaps(session.capabilities)}`;
+  getSessionInfo (session, serverType) {
+    if (serverType === ServerTypes.browserstack) {
+      return `${session.id} — ${formatCapsBrowserstack(session.capabilities)}`;
+    } else {
+      return `${session.id} — ${formatCaps(session.capabilities)}`;
+    }
   }
 
   render () {
-    let {attachSessId, setAttachSessId, runningAppiumSessions, getRunningSessions, t} = this.props;
+    let {serverType, attachSessId, setAttachSessId, runningAppiumSessions, getRunningSessions, t} = this.props;
     attachSessId = attachSessId || '';
     return (<Form>
       <FormItem>
@@ -43,7 +53,7 @@ export default class AttachToSession extends Component {
               value={attachSessId}
               onChange={(value) => setAttachSessId(value)}>
               {runningAppiumSessions.map((session) => <Select.Option key={session.id} value={session.id}>
-                <div>{this.getSessionInfo(session)}</div>
+                <div>{this.getSessionInfo(session, serverType)}</div>
               </Select.Option>)}
             </Select>
           </Col>

--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -27,10 +27,11 @@ function formatCapsBrowserstack (caps) {
 export default class AttachToSession extends Component {
 
   getSessionInfo (session, serverType) {
-    if (serverType === ServerTypes.browserstack) {
-      return `${session.id} — ${formatCapsBrowserstack(session.capabilities)}`;
-    } else {
-      return `${session.id} — ${formatCaps(session.capabilities)}`;
+    switch (serverType) {
+      case ServerTypes.browserstack:
+        return `${session.id} — ${formatCapsBrowserstack(session.capabilities)}`;
+      default:
+        return `${session.id} — ${formatCaps(session.capabilities)}`;
     }
   }
 

--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -12,6 +12,9 @@ function formatCaps (caps) {
   if (caps.automationName) {
     importantCaps.push(caps.automationName);
   }
+  if (caps.sessionName) {
+    importantCaps.push(caps.sessionName);
+  }
   return importantCaps.join(', ').trim();
 }
 


### PR DESCRIPTION
Once #1693 is merged users will be able to view the list of running sessions in the attach to session window. It is difficult to filter the sessions via the session-id, therefore, adding the `sessionName` (if present) to the list of `importantCaps`.

**Screenshot from the dev build**
<kbd>![sessionName in attach to session list](https://user-images.githubusercontent.com/10832531/107780683-03f23580-6d6d-11eb-930f-b8ebb3486666.png)</kbd>
