### PR TITLE
fix: attached sessions getting timeout due to inactivity

### DIFF
--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -195,6 +195,9 @@ function connectCreateNewSession () {
         // get the session capabilities to prove things are working
         await driver.sessionCapabilities();
         event.sender.send('appium-new-session-ready');
+        if (host !== '127.0.0.1' && host !== 'localhost') {
+          handler.runKeepAliveLoop();
+        }
         return;
       }
 


### PR DESCRIPTION
1. Attached sessions were getting timeout due to inactivity as we were not displaying the "Session Inactive" prompt to the user in case of an attached session.
2. This PR fixes the above issue and we start the `runKeepAliveLoop` similar to what we were doing for a regular session [here](https://github.com/appium/appium-desktop/blob/1.20/app/main/appium.js#L223-L225).