### PR TITLE
fix: stale session ids being displayed in the attach to session dropdown

### DIFF
--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -23,7 +23,7 @@ export default class AttachToSession extends Component {
 
   render () {
     let {attachSessId, setAttachSessId, runningAppiumSessions, getRunningSessions, t} = this.props;
-    attachSessId = attachSessId || '';
+    attachSessId = attachSessId || undefined;
     return (<Form>
       <FormItem>
         <Card>

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -68,6 +68,19 @@ const INITIAL_STATE = {
 
 let nextState;
 
+// returns false if the attachSessId is not present in the runningSessions list
+const isAttachSessIdValid = (runningSessions, attachSessId) => {
+  if (!attachSessId || !runningSessions) {
+    return false;
+  }
+  for (const session of runningSessions) {
+    if (session.id === attachSessId) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export default function session (state = INITIAL_STATE, action) {
   switch (action.type) {
     case NEW_SESSION_REQUESTED:
@@ -237,13 +250,15 @@ export default function session (state = INITIAL_STATE, action) {
         gettingSessions: true,
       };
 
-    case GET_SESSIONS_DONE:
+    case GET_SESSIONS_DONE: {
+      const attachSessId = isAttachSessIdValid(action.sessions, state.attachSessId) ? state.attachSessId : null;
       return {
         ...state,
         gettingSessions: false,
-        attachSessId: (action.sessions && action.sessions.length > 0 && !state.attachSessId) ? action.sessions[0].id : state.attachSessId,
+        attachSessId: (action.sessions && action.sessions.length > 0 && !attachSessId) ? action.sessions[0].id : attachSessId,
         runningAppiumSessions: action.sessions || [],
       };
+    }
 
     case ENABLE_DESIRED_CAPS_EDITOR:
       return {


### PR DESCRIPTION
1. Attach to session placeholder text `enterYourSessionId` was not getting displayed as we were setting the value to `''` in case there are no running sessions, however, the `antd` expects this value to be `undefined` instead. For reference check [this](https://stackoverflow.com/a/45558497) stackoverflow link.
2. Whenever the `GET_SESSIONS_DONE` event is received for the first time we set the `attachSessId` inside the `state` variable, however, for the subsequent occurrences of this event we never update the `state.attachSessId` as we had already set that once initially. This leads to stale sessions that are not running anymore and still getting listed. This stale entry is only removed if the user selects a valid entry from the dropdown so that the `SET_ATTACH_SESS_ID` event is triggered which updates the value of `state.attachSessId`, however, there could be scenarios where there are no running sessions anymore and therefore in this situation, there's no way to to get rid of this stale entry.
3. To fix the above issue I have created a method `isAttachSessIdValid` that validates whether the existing value of `state.attachSessId` is any more valid or not? If it's not valid then we update its value with the currently running session id. If there are no running sessions currently then we reset the value to `null` (which is the initial state) so that the placeholder text starts getting displayed.