### PR TITLE
fix hybrid element position determination

### DIFF
--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -239,7 +239,7 @@ export default class AppiumMethodHandler {
             isAndroid ? 'xpath' : '-ios class chain',
             isAndroid ? '//android.webkit.WebView' : '**/XCUIElementTypeWebView'
           );
-          if (!webViewPosition) {
+          if (el) {
             webViewPosition = await this.driver.getLocation(el.value);
           }
         } catch (ign) {}

--- a/app/main/appium-method-handler.js
+++ b/app/main/appium-method-handler.js
@@ -239,7 +239,9 @@ export default class AppiumMethodHandler {
             isAndroid ? 'xpath' : '-ios class chain',
             isAndroid ? '//android.webkit.WebView' : '**/XCUIElementTypeWebView'
           );
-          webViewPosition = await this.driver.getLocation(el.value);
+          if (!webViewPosition) {
+            webViewPosition = await this.driver.getLocation(el.value);
+          }
         } catch (ign) {}
         await this.driver.context(currentContext);
       }

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -802,29 +802,27 @@ export function setVisibleProviders () {
  * @param {object} caps
  */
 function addCustomCaps (caps) {
-  const {browserName = '', platformName = ''} = caps;
-  const safariCustomCaps = {
-    // Add the includeSafariInWebviews for future HTML detection
-    includeSafariInWebviews: true,
-  };
-  const chromeCustomCaps = {
+  const {platformName = ''} = caps;
+  const androidCustomCaps = {
+    // @TODO: remove when this is defaulted in the newest Appium 1.8.x release
+    ensureWebviewsHavePages: true,
     // Make sure the screenshot is taken of the whole screen when the ChromeDriver is used
+    // for or Chrome, or for Hybrid apps
     nativeWebScreenshot: true,
     // Set the ChromeDriver to w3c:false because all internal calls are still JSONWP calls
     chromeOptions: {
       'w3c': false,
     },
   };
-  const androidCustomCaps = {
-    // @TODO: remove when this is defaulted in the newest Appium 1.8.x release
-    ensureWebviewsHavePages: true,
+  const iosCustomCaps = {
+    // Always add the includeSafariInWebviews for future HTML detection
+    // This will ensure that if you use AD to switch between App and browser
+    // that it can detect Safari as a webview
+    includeSafariInWebviews: true,
   };
-  const iosCustomCaps = {};
 
   return {
     ...caps,
-    ...(browserName.toLowerCase() === 'safari' ? safariCustomCaps : {}),
-    ...(browserName.toLowerCase() === 'chrome' ? chromeCustomCaps : {}),
     ...(platformName.toLowerCase() === 'android' ? androidCustomCaps : {}),
     ...(platformName.toLowerCase() === 'ios' ? iosCustomCaps : {}),
   };


### PR DESCRIPTION
When switched to the webview of a hybrid app the elements on the screenshot were not aligned with the expected position.  See screenshot

 **Android:**
![image](https://user-images.githubusercontent.com/11979740/133603945-888ae74f-7cec-45e6-b60b-50260ba43a3e.png)

**iOS:**
![image](https://user-images.githubusercontent.com/11979740/133604405-21f0b134-699d-4607-81c2-7b8a01b47980.png)


This PR will fix that by determining the position of the first webview on in the hybrid app, see below

 **Android:**
![image](https://user-images.githubusercontent.com/11979740/133603057-62afa60b-0d09-4e13-8c93-a44905893192.png)

**iOS:**
![image](https://user-images.githubusercontent.com/11979740/133603420-5c5dde57-6548-40de-bd74-8b46256fee2c.png)


This will also fix the issue that Android hybrid apps got stuck when switching to the webview. The `nativeWebScreenshot` was needed to get a full screen screenshot instead of the ChromeDriver Webview screenshot