### PR TITLE
chore: comment out CSC

### DIFF
--- a/ci-jobs/templates/package.yml
+++ b/ci-jobs/templates/package.yml
@@ -32,5 +32,5 @@ jobs:
       displayName: Bundle
       env:
         GH_TOKEN: $(GH_TOKEN)
-        CSC_LINK: $(CSC_LINK)
-        CSC_KEY_PASSWORD: $(CSC_KEY_PASSWORD)
+        # CSC_LINK: $(CSC_LINK)
+        # CSC_KEY_PASSWORD: $(CSC_KEY_PASSWORD)


### PR DESCRIPTION
https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=20481&view=logs&j=f87c6499-3401-572f-ac24-cec18d4bfbce&t=4032fcf8-7e70-54e0-2d0a-53cd538a71f4 failed in Win build as code signature has been expired.

I don't know where sets the signature. Probably the below section in the Azure??? I don't know the exact value neighter.
<img width="300" alt="Screen Shot 2022-03-28 at 0 05 20" src="https://user-images.githubusercontent.com/5511591/160344139-7d5f531e-36ad-44ac-80dc-3c7a7cd0e272.png">

In my local Win app (Win 10 env though) worked without the sign. So, a module by `npx electron-builder build -w --ia32 --x64` worked.

So, I wonder we can remove `CSC_LINK` for this purpose since we won't publish these apps to their online store. Or we probably can ask JSFoundation...? @jlipps 

https://github.com/appium/appium-desktop/releases/tag/v1.22.3 's Win modules are built by `npx electron-builder build -w --ia32 --x64 --publish never` on my local without such `CSC_*`. We can merge this PR if we do not get any errors by such signatures in the version.


----

https://github.com/appium/appium-desktop/issues/1995